### PR TITLE
Feat: 개인캘린더 화면 양옆 컴포넌트 구현 (#21)

### DIFF
--- a/src/pages/Calendar/FullCalendar.tsx
+++ b/src/pages/Calendar/FullCalendar.tsx
@@ -22,12 +22,12 @@ const CalendarPage = () => {
   const plugins = useMemo(() => [dayGridPlugin, timeGridPlugin, interactionPlugin], []);
 
   return (
-    <div className="p-6 min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+    <div className="p-4 min-h-screen">
       <div className="mx-auto max-w-7xl">
-        <div className="mb-8">
+        {/* <div className="mb-8">
           <h1 className="mb-2 text-3xl font-bold text-gray-900">일정 관리</h1>
           <p className="text-gray-600">팀 일정을 효율적으로 관리하세요</p>
-        </div>
+        </div> */}
 
         <div className="overflow-hidden bg-white rounded-2xl shadow-xl">
           <div className="p-6">

--- a/src/pages/PersonalCalendar/LinkStatus/LinkStatus.tsx
+++ b/src/pages/PersonalCalendar/LinkStatus/LinkStatus.tsx
@@ -1,0 +1,44 @@
+import TimeTableModal from '@/pages/Calendar/components/TimetableModal/TimetableModal';
+import { Link } from 'lucide-react';
+import { useState } from 'react';
+
+const LinkStatus = () => {
+  const [linkStatus, setLinkStatus] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const handleLinkStatus = () => {
+    if (linkStatus) {
+      return;
+    }
+    // TODO: 실제 연동 로직 추가
+    setIsOpen(true);
+    setLinkStatus(true);
+  };
+
+  return (
+    <>
+      <TimeTableModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
+      <div className="overflow-hidden p-6 bg-white rounded-xl border shadow-lg border-mainBlue/70">
+        <div className="flex gap-2 items-center mb-2">
+          <Link className="w-4 h-4 text-mainBlue" />
+          <h3 className="text-lg font-semibold text-mainBlue">연동 상태</h3>
+        </div>
+        <div className="flex flex-row justify-between items-center bg-white">
+          <p className="text-sm font-medium text-[#1C398E]">에브리타임 연동</p>
+          <div>
+            {linkStatus ? (
+              <p className="text-sm font-medium px-2 py-1 text-[#1C398E]">연동완료</p>
+            ) : (
+              <button
+                className="text-sm border text-nowrap border-mainBlue rounded-lg px-2 py-1 font-medium text-[#1C398E] hover:cursor-pointer transition hover:bg-mainBlue/50 hover:text-white"
+                onClick={handleLinkStatus}
+              >
+                연동하기
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+export default LinkStatus;

--- a/src/pages/PersonalCalendar/PersonalCalendar.tsx
+++ b/src/pages/PersonalCalendar/PersonalCalendar.tsx
@@ -1,16 +1,30 @@
 import Drawer from '@/components/common/Drawer/Drawer';
 import FullCalendar from '@/pages/Calendar/FullCalendar';
-import TodaySchedule from '@/pages/PersonalCalendar/components/TodaySchedule';
-
+import LinkStatus from '@/pages/PersonalCalendar/components/LinkStatus';
+import MyClass from '@/pages/PersonalCalendar/sidebar-components/MyClass';
+import MyTeam from '@/pages/PersonalCalendar/sidebar-components/MyTeam';
+import QuickActions from '@/pages/PersonalCalendar/sidebar-components/QuickActions';
+import TodaySchedule from '@/pages/PersonalCalendar/sidebar-components/TodaySchedule';
+import UpcomingSchedule from '@/pages/PersonalCalendar/UpcomingSchedule/UpcomingSchedule';
 const PersonalCalendarPage = () => {
   return (
     <div className="flex min-h-screen">
       <Drawer>
+        <QuickActions />
+        <MyClass />
+        <MyTeam />
         <TodaySchedule />
       </Drawer>
 
-      <div className="flex-1 p-0 md:ml-0">
-        <FullCalendar />
+      <div className="flex flex-col flex-1 bg-gradient-to-br from-blue-50 to-indigo-100 lg:flex-row">
+        <div className="flex-1 lg:flex-[3]">
+          <FullCalendar />
+        </div>
+
+        <div className="flex flex-col m-4 gap-4 lg:flex-[1] lg:max-w-sm">
+          <UpcomingSchedule />
+          <LinkStatus />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/PersonalCalendar/PersonalCalendar.tsx
+++ b/src/pages/PersonalCalendar/PersonalCalendar.tsx
@@ -1,6 +1,6 @@
 import Drawer from '@/components/common/Drawer/Drawer';
 import FullCalendar from '@/pages/Calendar/FullCalendar';
-import LinkStatus from '@/pages/PersonalCalendar/components/LinkStatus';
+import LinkStatus from '@/pages/PersonalCalendar/LinkStatus/LinkStatus';
 import MyClass from '@/pages/PersonalCalendar/sidebar-components/MyClass';
 import MyTeam from '@/pages/PersonalCalendar/sidebar-components/MyTeam';
 import QuickActions from '@/pages/PersonalCalendar/sidebar-components/QuickActions';

--- a/src/pages/PersonalCalendar/UpcomingSchedule/UpcomingSchedule.tsx
+++ b/src/pages/PersonalCalendar/UpcomingSchedule/UpcomingSchedule.tsx
@@ -1,0 +1,16 @@
+import { AlarmClock } from 'lucide-react';
+import { UpcomingScheduleList } from './UpcomingScheduleList';
+
+const UpcomingSchedule = () => {
+  return (
+    <div className="overflow-hidden p-6 bg-white rounded-xl border shadow-lg border-mainBlue">
+      <div className="flex gap-2 items-center mb-2">
+        <AlarmClock className="w-4 h-4 text-mainBlue" />
+        <h3 className="text-lg font-semibold text-mainBlue">다가오는 일정</h3>
+      </div>
+      <UpcomingScheduleList />
+    </div>
+  );
+};
+
+export default UpcomingSchedule;

--- a/src/pages/PersonalCalendar/UpcomingSchedule/UpcomingSchedule.tsx
+++ b/src/pages/PersonalCalendar/UpcomingSchedule/UpcomingSchedule.tsx
@@ -3,7 +3,7 @@ import { UpcomingScheduleList } from './UpcomingScheduleList';
 
 const UpcomingSchedule = () => {
   return (
-    <div className="overflow-hidden p-6 bg-white rounded-xl border shadow-lg border-mainBlue">
+    <div className="overflow-hidden p-6 bg-white rounded-xl border shadow-lg border-mainBlue/70">
       <div className="flex gap-2 items-center mb-2">
         <AlarmClock className="w-4 h-4 text-mainBlue" />
         <h3 className="text-lg font-semibold text-mainBlue">다가오는 일정</h3>

--- a/src/pages/PersonalCalendar/UpcomingSchedule/UpcomingScheduleItem.tsx
+++ b/src/pages/PersonalCalendar/UpcomingSchedule/UpcomingScheduleItem.tsx
@@ -1,0 +1,25 @@
+import { upcomingSchedule } from './schedule';
+
+export const UpcomingScheduleItem = ({ schedule }: { schedule: (typeof upcomingSchedule)[0] }) => {
+  const today = new Date();
+  const targetDate = new Date(schedule.date);
+  const diffTime = Math.abs(targetDate.getTime() - today.getTime());
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  return (
+    <div className="flex flex-row justify-between items-center p-2 bg-white rounded-lg border border-mainBlue/40">
+      <div>
+        <p className="text-sm font-medium text-[#1C398E]">{schedule.title}</p>
+        <p className="text-xs text-mainBlue">{schedule.date}</p>
+      </div>
+      {diffDays < 2 ? (
+        <div className="flex gap-1 items-center p-1 rounded-lg bg-red-100/80">
+          <p className="text-xs text-red-500">D-{diffDays}</p>
+        </div>
+      ) : (
+        <div className="flex gap-1 items-center p-1 rounded-lg bg-gray-100/80">
+          <p className="text-xs text-gray-500">D-{diffDays}</p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/pages/PersonalCalendar/UpcomingSchedule/UpcomingScheduleList.tsx
+++ b/src/pages/PersonalCalendar/UpcomingSchedule/UpcomingScheduleList.tsx
@@ -1,0 +1,12 @@
+import { upcomingSchedule } from './schedule';
+import { UpcomingScheduleItem } from './UpcomingScheduleItem';
+
+export const UpcomingScheduleList = () => {
+  return (
+    <div className="space-y-2">
+      {upcomingSchedule.map((schedule) => (
+        <UpcomingScheduleItem key={schedule.title} schedule={schedule} />
+      ))}
+    </div>
+  );
+};

--- a/src/pages/PersonalCalendar/UpcomingSchedule/schedule.ts
+++ b/src/pages/PersonalCalendar/UpcomingSchedule/schedule.ts
@@ -1,0 +1,17 @@
+export const upcomingSchedule = [
+  {
+    title: '데이터구조',
+    date: '2025-09-10',
+    time: '10:00',
+  },
+  {
+    title: '웹프로그래밍',
+    date: '2025-09-11',
+    time: '12:00',
+  },
+  {
+    title: '알고리즘',
+    date: '2025-09-12',
+    time: '16:00',
+  },
+];

--- a/src/pages/PersonalCalendar/components/LinkStatus.tsx
+++ b/src/pages/PersonalCalendar/components/LinkStatus.tsx
@@ -1,5 +1,0 @@
-const LinkStatus = () => {
-  return <div>LinkStatus</div>;
-};
-
-export default LinkStatus;

--- a/src/pages/PersonalCalendar/components/LinkStatus.tsx
+++ b/src/pages/PersonalCalendar/components/LinkStatus.tsx
@@ -1,0 +1,5 @@
+const LinkStatus = () => {
+  return <div>LinkStatus</div>;
+};
+
+export default LinkStatus;

--- a/src/pages/PersonalCalendar/sidebar-components/MyClass.tsx
+++ b/src/pages/PersonalCalendar/sidebar-components/MyClass.tsx
@@ -1,0 +1,33 @@
+const MyClass = () => {
+  const classes = [
+    { name: '데이터구조', instructor: '김영훈', color: 'bg-blue-500' },
+    { name: '웹프로그래발', instructor: '이영훈', color: 'bg-green-500' },
+    { name: '알고리즘', instructor: '박영훈', color: 'bg-green-500' },
+  ];
+
+  return (
+    <div className="px-3 mb-8">
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="text-lg font-semibold text-gray-800">내 수업 ({classes.length})</h3>
+        <button className="p-1 text-sm rounded-md text-mainBlue hover:text-mainBlue/80">
+          설정
+        </button>
+      </div>
+      <div className="space-y-3">
+        {classes.map((classItem, index) => (
+          <div key={index} className="flex justify-between items-center p-2 pl-0 rounded-lg">
+            <div className="flex items-center">
+              <div className={`w-3 h-3 rounded-full ${classItem.color} mr-2`} />
+              <div>
+                <p className="text-xs font-medium text-gray-800">{classItem.name}</p>
+                <p className="text-xs text-gray-500">{classItem.instructor}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default MyClass;

--- a/src/pages/PersonalCalendar/sidebar-components/MyTeam.tsx
+++ b/src/pages/PersonalCalendar/sidebar-components/MyTeam.tsx
@@ -1,0 +1,37 @@
+const MyTeam = () => {
+  const teams = [
+    { name: '프로그래밍 조별과제', members: 3, color: 'bg-blue-500' },
+    { name: '프로그래밍 동아리', members: 12, color: 'bg-green-500' },
+    { name: '프로그래밍 동아리', members: 12, color: 'bg-green-500' },
+    { name: '알고리즘스터디', members: 4, color: 'bg-purple-500' },
+  ];
+
+  return (
+    <div className="px-3 mb-8">
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="text-lg font-semibold text-gray-800">내 팀 ({teams.length})</h3>
+        <button className="p-1 text-sm rounded-md text-mainBlue hover:text-mainBlue/80">
+          설정
+        </button>
+      </div>
+      <div className="space-y-3">
+        {teams.map((team, index) => (
+          <div key={index} className="flex justify-between items-center p-2 pl-0 rounded-lg">
+            <div className="flex items-center">
+              <div className={`w-3 h-3 rounded-full ${team.color} mr-2`} />
+              <div>
+                <p className="text-xs font-medium text-gray-800">{team.name}</p>
+                <p className="text-xs text-gray-500">{team.members}명</p>
+              </div>
+            </div>
+            <button className="px-3 py-1 text-xs text-blue-600 bg-blue-50 rounded-md transition-colors hover:bg-blue-100">
+              이동
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default MyTeam;

--- a/src/pages/PersonalCalendar/sidebar-components/QuickActions.tsx
+++ b/src/pages/PersonalCalendar/sidebar-components/QuickActions.tsx
@@ -1,0 +1,23 @@
+import { Clock, Plus, Users } from 'lucide-react';
+
+const QuickActions = () => {
+  return (
+    <div className="px-3 mb-8">
+      <h3 className="mb-4 text-lg font-semibold text-gray-800">빠른 작업</h3>
+      <div className="space-y-3">
+        <button className="flex items-center px-4 py-2 w-full text-white bg-blue-600 rounded-lg transition-colors hover:bg-blue-700">
+          <Plus className="mr-3 w-5 h-5" />새 일정 추가
+        </button>
+        <button className="flex items-center px-4 py-2 w-full text-gray-700 bg-white rounded-lg border border-gray-300 transition-colors hover:bg-gray-50">
+          <Users className="mr-3 w-5 h-5" />팀 생성하기
+        </button>
+        <button className="flex items-center px-4 py-2 w-full text-gray-700 bg-white rounded-lg border border-gray-300 transition-colors hover:bg-gray-50">
+          <Clock className="mr-3 w-5 h-5" />
+          가능한 시간 찾기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default QuickActions;

--- a/src/pages/PersonalCalendar/sidebar-components/TodaySchedule.tsx
+++ b/src/pages/PersonalCalendar/sidebar-components/TodaySchedule.tsx
@@ -8,11 +8,11 @@ const TodaySchedule = () => {
   ];
 
   return (
-    <div className="mb-8">
+    <div className="px-3 mb-8">
       <h3 className="mb-4 text-lg font-semibold text-gray-800">오늘 일정</h3>
       <div className="space-y-3">
         {schedules.map((schedule, index) => (
-          <div key={index} className="flex flex-row p-3 bg-white rounded-lg">
+          <div key={index} className="flex flex-row p-2 pl-0 bg-white rounded-lg">
             <div className="flex justify-between items-center mr-4 mb-1">
               <span className="text-sm font-medium text-mainBlue">{schedule.time}</span>
             </div>


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요

* 개인 캘린더 페이지의 반응형 레이아웃 구현
* 캘린더와 사이드바 컴포넌트들의 적절한 배치 및 반응형 처리
* 에브리타임 연동 기능을 위한 모달 연동

# 어떻게 해결했나요
- [ ] 반응형 레이아웃 구현:
* 큰 화면(lg 이상)에서는 캘린더가 왼쪽 3/4 공간을 차지하고, UpcomingSchedule(다가오는 일정) 와 LinkStatus(연동 상태)이 오른쪽에 위아래로 배치
* 작은 화면에서는 모든 컴포넌트가 세로로 배치되도록 flex-col과 lg:flex-row 클래스 활용
- [ ] 컴포넌트 구조 개선:
* LinkStatus와 UpcomingSchedule 컴포넌트를 별도 폴더로 분리하여 구조화
* LinkStatus 컴포넌트에 연동 상태 관리 및 모달 연동 기능 추가

# 어떤 부분에 집중하여 리뷰해야 할까요?
* 반응형 레이아웃: 다양한 화면 크기에서 레이아웃이 올바르게 작동하는지 확인
* 컴포넌트 분리: LinkStatus와 UpcomingSchedule 컴포넌트의 독립성과 재사용성
* 모달 연동: TimeTableModal과의 연동이 올바르게 작동하는지 확인
* 스타일링: FullCalendar bg를 PersonalCalendar bg 로 이동, 오른쪽 추가된 컴포넌트들의 보더 색이 적절한지?