### PR TITLE
Fix: 캘린더 페이지 이슈 수정

### DIFF
--- a/src/pages/Calendar/FullCalendar.tsx
+++ b/src/pages/Calendar/FullCalendar.tsx
@@ -48,7 +48,7 @@ const CalendarPage = () => {
   }, [currentDate, currentView]);
 
   return (
-    <div className="p-4">
+    <div className="p-2">
       <div className="mx-auto max-w-7xl">
         {/* <div className="mb-8">
           <h1 className="mb-2 text-3xl font-bold text-gray-900">일정 관리</h1>
@@ -56,7 +56,7 @@ const CalendarPage = () => {
         </div> */}
 
         <div className="overflow-hidden bg-white rounded-2xl shadow-xl">
-          <div className="p-6">
+          <div className="p-1 py-4 sm:p-6">
             <FullCalendar
               ref={calendarRef}
               plugins={plugins}

--- a/src/pages/PersonalCalendar/index.tsx
+++ b/src/pages/PersonalCalendar/index.tsx
@@ -9,20 +9,24 @@ import UpcomingSchedule from '@/pages/PersonalCalendar/components/UpcomingSchedu
 
 const PersonalCalendarPage = () => {
   return (
-    <div className="min-h-screen">
-      <Drawer>
-        <QuickActions />
-        <MyClass />
-        <MyTeam />
-        <TodaySchedule />
-      </Drawer>
+    <div className="flex overflow-x-hidden min-h-screen">
+      {/* 사이드바 영역 - 큰 화면에서는 고정 너비 */}
+      <div className="xl:w-60 xl:flex-shrink-0">
+        <Drawer>
+          <QuickActions />
+          <MyClass />
+          <MyTeam />
+          <TodaySchedule />
+        </Drawer>
+      </div>
 
-      <div className="flex flex-col flex-1 pb-4 bg-gradient-to-br from-blue-50 to-indigo-100 lg:flex-row">
+      {/* 메인 콘텐츠 영역 */}
+      <div className="flex overflow-x-hidden flex-col flex-1 pb-4 bg-gradient-to-br from-blue-50 to-indigo-100 lg:flex-row xl:pl-0">
         <div className="flex-1 lg:flex-[3]">
           <FullCalendar />
         </div>
 
-        <div className="flex flex-col m-4 gap-8 lg:flex-[1] lg:max-w-sm">
+        <div className="flex flex-col m-2 gap-8 lg:flex-[1] lg:max-w-sm">
           <UpcomingSchedule />
           <LinkStatus />
         </div>

--- a/src/styles/fullCalendar.css
+++ b/src/styles/fullCalendar.css
@@ -57,7 +57,7 @@
   }
 
   .fc-toolbar-title {
-    @apply text-xl font-semibold text-gray-900;
+    @apply text-xl font-semibold text-gray-900 w-[160px];
   }
 
   /* 헤더 버튼 그룹 스타일 */

--- a/src/styles/fullCalendar.css
+++ b/src/styles/fullCalendar.css
@@ -170,7 +170,7 @@
 
   /* 날짜 셀 스타일 */
   .fc-daygrid-day {
-    @apply !rounded-none !m-0 !p-1 !overflow-visible !border-none;
+    @apply !rounded-none !m-0 !p-1 !overflow-visible !border-none text-sm;
   }
 
   .fc-daygrid-day-frame {


### PR DESCRIPTION
## 수정사항 
* 캘린더 스크롤 현상 및 짤림
* 캘린더 타이틀 너비 

## 수정 한 방법
* 스크롤 -> 캘린더의 패딩을 휴대폰 화면일때 (sm) 축소 (기존6 -> p-1, py-4)
* 타이틀 -> w-[160px] 고정

## 이미지
<img width="553" height="739" alt="스크린샷 2025-09-17 오전 12 22 13" src="https://github.com/user-attachments/assets/ae4a9a79-fde3-4c87-ad9f-4b0d5c5409f5" />
