### PR TITLE
Feat: 팀 주간 일정 탭 구현

### DIFF
--- a/src/components/atoms/SelectBox.tsx
+++ b/src/components/atoms/SelectBox.tsx
@@ -1,14 +1,14 @@
-import type { TimeOption } from '@/utils/timeUtils';
+import type { SelectOption } from '@/utils/timeUtils';
 
-interface TimeSelectorProps {
+interface SelectBoxProps {
   label: string;
   value: number;
   onChange: (value: number) => void;
-  options: TimeOption[];
+  options: SelectOption[];
   className?: string;
 }
 
-const TimeSelector: React.FC<TimeSelectorProps> = ({
+const SelectBox: React.FC<SelectBoxProps> = ({
   label,
   value,
   onChange,
@@ -18,7 +18,7 @@ const TimeSelector: React.FC<TimeSelectorProps> = ({
   return (
     <div className={`mb-4 sm:mb-6 ${className}`}>
       <label
-        htmlFor={`time-selector-${label}`}
+        htmlFor={`select-box-${label}`}
         className="block text-xs sm:text-sm font-medium text-gray-700 mb-2"
       >
         {label}
@@ -50,4 +50,4 @@ const TimeSelector: React.FC<TimeSelectorProps> = ({
   );
 };
 
-export default TimeSelector;
+export default SelectBox;

--- a/src/components/atoms/SelectBox.tsx
+++ b/src/components/atoms/SelectBox.tsx
@@ -19,7 +19,7 @@ const SelectBox: React.FC<SelectBoxProps> = ({
     <div className={`mb-4 sm:mb-6 ${className}`}>
       <label
         htmlFor={`select-box-${label}`}
-        className="block text-xs sm:text-sm font-medium text-gray-700 mb-2"
+        className="block text-sm sm:text-sm font-medium text-gray-700 mb-2"
       >
         {label}
       </label>
@@ -27,7 +27,7 @@ const SelectBox: React.FC<SelectBoxProps> = ({
         <select
           value={value}
           onChange={(e) => onChange(Number(e.target.value))}
-          className="w-full px-2 sm:px-3 py-2 sm:py-3 pr-8 sm:pr-10 border border-gray-200 rounded-lg text-xs sm:text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-transparent bg-white appearance-none cursor-pointer transition-all duration-200"
+          className="w-full px-2 sm:px-3 py-2 sm:py-3 pr-8 sm:pr-10 border border-gray-200 rounded-lg text-md sm:text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-transparent bg-white appearance-none cursor-pointer transition-all duration-200"
         >
           {options.map((option) => (
             <option key={option.value} value={option.value}>

--- a/src/components/organisms/Drawer.tsx
+++ b/src/components/organisms/Drawer.tsx
@@ -42,6 +42,7 @@ const Drawer = ({ children, className = '' }: DrawerProps) => {
         className={`
           fixed xl:relative top-0 left-0 z-50 xl:z-auto
           transform transition-transform duration-300 ease-in-out
+          min-w-60
           ${isOpen ? 'translate-x-0' : '-translate-x-full xl:translate-x-0'}
           ${className}
         `}

--- a/src/mockdata/scheduleData.ts
+++ b/src/mockdata/scheduleData.ts
@@ -16,6 +16,37 @@ export const upcomingSchedule = [
   },
 ];
 
+export const upcomingTeamSchedule = [
+  {
+    title: '졸업과제 회의',
+    date: '9월 12일 금요일',
+    startTime: '11:00',
+    endTime: '13:00',
+    location: '운죽정',
+  },
+  {
+    title: '졸업과제 미팅',
+    date: '9월 18일 목요일',
+    startTime: '14:00',
+    endTime: '16:00',
+    location: '제6공학관',
+  },
+  {
+    title: '졸업과제 발표',
+    date: '10월 1일 수요일',
+    startTime: '10:00',
+    endTime: '12:00',
+    location: 'IT관 3층',
+  },
+  {
+    title: '졸업과제 심사',
+    date: '10월 1일 수요일',
+    startTime: '10:00',
+    endTime: '12:00',
+    location: 'IT관 3층',
+  },
+];
+
 export const classes = [
   { name: '데이터구조', instructor: '김영훈', color: 'bg-blue-500' },
   { name: '웹프로그래발', instructor: '이영훈', color: 'bg-green-500' },

--- a/src/mockdata/teamData.ts
+++ b/src/mockdata/teamData.ts
@@ -40,6 +40,13 @@ export const mockTimeSlots: TimeSlot[] = [
     participants: '6/8명 참석 가능',
     tag: '좋음',
   },
+  {
+    id: 5,
+    day: '9월 14일 목요일',
+    time: '11:00-13:00',
+    participants: '6/8명 참석 가능',
+    tag: '좋음',
+  },
 ];
 
 export const mockTeams: Team[] = [

--- a/src/pages/TeamCalendar/components/RecommendTimes.tsx
+++ b/src/pages/TeamCalendar/components/RecommendTimes.tsx
@@ -9,7 +9,7 @@ const RecommendTimes: React.FC = () => {
   const timeOptions = generateTimeOptions(4);
 
   return (
-    <div className="w-full">
+    <div className="w-full bg-white overflow-hidden p-6 rounded-xl border shadow-lg border-mainBlue/70">
       <h2 className="text-lg font-semibold text-gray-800 mb-4">가장 빠른 팀 일정 추천</h2>
 
       <div className="xl:block hidden">

--- a/src/pages/TeamCalendar/components/RecommendTimes.tsx
+++ b/src/pages/TeamCalendar/components/RecommendTimes.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { mockTimeSlots } from '@/mockdata/teamData';
-import TimeSelector from '@/components/atoms/SelectBox';
+import TimeBox from '@/components/atoms/SelectBox';
 import Button from '@/components/atoms/Button';
 import { generateTimeOptions } from '@/utils/timeUtils';
 
@@ -13,7 +13,7 @@ const RecommendTimes: React.FC = () => {
       <h2 className="text-lg font-semibold text-gray-800 mb-4">가장 빠른 팀 일정 추천</h2>
 
       <div className="xl:block hidden">
-        <TimeSelector
+        <TimeBox
           label="최소 요구 시간"
           value={selectedDuration}
           onChange={setSelectedDuration}
@@ -42,7 +42,7 @@ const RecommendTimes: React.FC = () => {
 
       <div className="xl:hidden block">
         <div className="mb-4">
-          <TimeSelector
+          <TimeBox
             label="최소 요구 시간"
             value={selectedDuration}
             onChange={setSelectedDuration}

--- a/src/pages/TeamCalendar/components/TeamMembers.tsx
+++ b/src/pages/TeamCalendar/components/TeamMembers.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { ChevronDown, ChevronUp, Settings } from 'lucide-react';
 import { mockMembers } from '@/mockdata/teamData';
-import SearchBar from '@/components/atoms/SearchBar';
+//import SearchBar from '@/components/atoms/SearchBar';
 
 interface TeamMembersProps {
   onSettingsClick?: () => void;
@@ -23,7 +23,7 @@ const TeamMembers: React.FC<TeamMembersProps> = ({ onSettingsClick }) => {
             <ChevronDown className="w-4 h-4 text-blue-500" />
           )}
         </div>
-                <button 
+        <button
           className="text-gray-400 hover:text-blue-600 transition-colors duration-200 p-2 hover:bg-blue-50 rounded-full"
           onClick={onSettingsClick}
         >
@@ -31,11 +31,13 @@ const TeamMembers: React.FC<TeamMembersProps> = ({ onSettingsClick }) => {
         </button>
       </div>
 
+      {/**
       {isOpen && (
         <div className="mt-4">
           <SearchBar placeholder="팀원 검색하기" />
         </div>
       )}
+      **/}
 
       {isOpen && (
         <div className="mt-4 max-h-60 overflow-y-auto space-y-2">
@@ -68,6 +70,9 @@ const TeamMembers: React.FC<TeamMembersProps> = ({ onSettingsClick }) => {
         </div>
       )}
 
+      {isOpen && mockMembers.length > 5 && (
+        <p className="text-xs text-center text-gray-400 mt-2">스크롤하여 팀원 더보기</p>
+      )}
     </div>
   );
 };

--- a/src/pages/TeamCalendar/components/UpcomingTeamSchedule.tsx
+++ b/src/pages/TeamCalendar/components/UpcomingTeamSchedule.tsx
@@ -1,0 +1,16 @@
+import { UpcomingTeamScheduleList } from '@/pages/TeamCalendar/components/UpcomingTeamScheduleList';
+
+const UpcomingTeamSchedule = () => {
+  return (
+    <>
+      <div className="overflow-hidden rounded-xl">
+        <div className="flex flex-col gap-2 mb-2">
+          <h3 className="text-lg font-semibold">팀 주간 일정</h3>
+          <UpcomingTeamScheduleList />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default UpcomingTeamSchedule;

--- a/src/pages/TeamCalendar/components/UpcomingTeamScheduleItem.tsx
+++ b/src/pages/TeamCalendar/components/UpcomingTeamScheduleItem.tsx
@@ -1,0 +1,23 @@
+import { upcomingTeamSchedule } from '@/mockdata/scheduleData';
+import { MapPin } from 'lucide-react';
+
+export const UpcomingTeamScheduleItem = ({
+  schedule,
+}: {
+  schedule: (typeof upcomingTeamSchedule)[0];
+}) => {
+  return (
+    <div className="flex flex-row justify-between items-center p-3 bg-white rounded-lg border border-mainBlue/40">
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-[#1C398E]">{schedule.title}</p>
+        <p className="text-xs text-mainBlue">
+          {schedule.date} {schedule.startTime}-{schedule.endTime}
+        </p>
+        <p className="flex gap-1 items-center text-xs text-mainBlue">
+          <MapPin className="w-4 h-4" />
+          {schedule.location}
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/TeamCalendar/components/UpcomingTeamScheduleList.tsx
+++ b/src/pages/TeamCalendar/components/UpcomingTeamScheduleList.tsx
@@ -1,0 +1,12 @@
+import { UpcomingTeamScheduleItem } from '@/pages/TeamCalendar/components/UpcomingTeamScheduleItem';
+import { upcomingTeamSchedule } from '@/mockdata/scheduleData';
+
+export const UpcomingTeamScheduleList = () => {
+  return (
+    <div className="space-y-2">
+      {upcomingTeamSchedule.map((schedule) => (
+        <UpcomingTeamScheduleItem key={schedule.title} schedule={schedule} />
+      ))}
+    </div>
+  );
+};

--- a/src/pages/TeamCalendar/index.tsx
+++ b/src/pages/TeamCalendar/index.tsx
@@ -38,7 +38,7 @@ const TeamCalendarPage = () => {
 
           <div className="flex flex-col flex-1">
             <div className="overflow-x-auto order-b border-gray-200">
-              <div className="p-4 rounded-lg border border-gray-100">
+              <div className="p-2 rounded-lg border border-gray-100">
                 <RecommendTimes />
               </div>
             </div>

--- a/src/pages/TeamCalendar/index.tsx
+++ b/src/pages/TeamCalendar/index.tsx
@@ -10,16 +10,16 @@ const TeamCalendarPage = () => {
 
   return (
     <div className="min-h-screen">
-      <div className="hidden min-h-screen transition-all duration-500 ease-in-out xl:flex">
+      <div className="hidden min-h-screen transition-all duration-500 uration-500 ease-in-out bg-gradient-to-br from-blue-50 to-indigo-100 ease-in-out xl:flex">
         <Drawer>
           <TeamMembers onSettingsClick={() => setIsTeamListModalOpen(true)} />
         </Drawer>
 
-        <div className="flex-1 p-0 transition-all duration-500 ease-in-out">
+        <div className="flex-1 transition-all duration-500 ease-in-out">
           <FullCalendar />
         </div>
 
-        <div className="p-2 w-80 bg-gray-50 border-l border-gray-200 transition-all duration-500 ease-in-out transform">
+        <div className="pr-4 pt-2 pl-2 w-80 transition-all duration-500 ease-in-out transform">
           <div className="transition-all duration-300 ease-out transform">
             <RecommendTimes />
           </div>
@@ -28,14 +28,14 @@ const TeamCalendarPage = () => {
 
       {/*모바일 뷰*/}
       <div className="block min-h-screen xl:hidden">
-        <div className="flex flex-col min-h-screen">
+        <div className="flex flex-col min-h-screen uration-500 ease-in-out bg-gradient-to-br from-blue-50 to-indigo-100">
           <Drawer>
             <TeamMembers onSettingsClick={() => setIsTeamListModalOpen(true)} />
           </Drawer>
 
           <div className="flex flex-col flex-1">
-            <div className="overflow-x-auto p-2 bg-gray-50 border-b border-gray-200">
-              <div className="p-4 bg-white rounded-lg border border-gray-100">
+            <div className="overflow-x-auto order-b border-gray-200">
+              <div className="p-4 rounded-lg border border-gray-100">
                 <RecommendTimes />
               </div>
             </div>

--- a/src/pages/TeamCalendar/index.tsx
+++ b/src/pages/TeamCalendar/index.tsx
@@ -1,18 +1,20 @@
+import { useState } from 'react';
 import Drawer from '@/components/organisms/Drawer';
 import FullCalendar from '@/pages/Calendar/FullCalendar';
 import RecommendTimes from '@/pages/TeamCalendar/components/RecommendTimes';
 import TeamListModal from '@/pages/TeamCalendar/components/TeamListModal';
 import TeamMembers from '@/pages/TeamCalendar/components/TeamMembers';
-import { useState } from 'react';
+import UpcomingTeamSchedule from '@/pages/TeamCalendar/components/UpcomingTeamSchedule';
 
 const TeamCalendarPage = () => {
   const [isTeamListModalOpen, setIsTeamListModalOpen] = useState(false);
 
   return (
-    <div className="min-h-screen">
-      <div className="hidden min-h-screen transition-all duration-500 uration-500 ease-in-out bg-gradient-to-br from-blue-50 to-indigo-100 ease-in-out xl:flex">
+    <div className="min-h-[calc(100vh-70px)] flex">
+      <div className="hidden transition-all duration-500 uration-500 ease-in-out bg-gradient-to-br from-blue-50 to-indigo-100 ease-in-out xl:flex">
         <Drawer>
           <TeamMembers onSettingsClick={() => setIsTeamListModalOpen(true)} />
+          <UpcomingTeamSchedule />
         </Drawer>
 
         <div className="flex-1 transition-all duration-500 ease-in-out">
@@ -31,6 +33,7 @@ const TeamCalendarPage = () => {
         <div className="flex flex-col min-h-screen uration-500 ease-in-out bg-gradient-to-br from-blue-50 to-indigo-100">
           <Drawer>
             <TeamMembers onSettingsClick={() => setIsTeamListModalOpen(true)} />
+            <UpcomingTeamSchedule />
           </Drawer>
 
           <div className="flex flex-col flex-1">

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -1,10 +1,10 @@
-export interface TimeOption {
+export interface SelectOption {
   value: number;
   label: string;
 }
 
-export const generateTimeOptions = (maxHours: number = 4): TimeOption[] => {
-  const options: TimeOption[] = [];
+export const generateTimeOptions = (maxHours: number = 4): SelectOption[] => {
+  const options: SelectOption[] = [];
 
   for (let hours = 0; hours <= maxHours; hours++) {
     for (let minutes = 0; minutes < 60; minutes += 15) {


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요

팀 캘린더 페이지 드로어의 팀 주간 일정 탭을 구현하였습니다.

# 어떻게 해결했나요

[구현]
- 개인 캘린더 페이지의 `UpcomingSchedule`파일을 참고하여 구현하였습니다.
- mockdata를 작성하여 `scheduleData.ts`의 `upcomingTeamSchedule`로 분리하였습니다.

[수정]
- 팀 캘린더 페이지의 배경색을 개인 캘린더 페이지와 통일하였습니다.
- 팀 캘린더 페이지의 일정 추천 탭 디자인을 개인 캘린더 페이지와 통일하였습니다.
- 팀 캘린더의 드로어의 팀원 탭에서 검색바를 삭제하고 사용자가 스크롤 가능하다는 점을 인지할 수 있도록 하단에 description을 추가하였습니다.
- 팀원 탭을 닫으면 드로어의 width가 함께 축소되는 문제가 발생하여 `Drawer` 컴포넌트의 최소 width를 지정하였습니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?
* 불필요한 코드는 없는지
* 디자인이 개인 캘린더와 통일되었는지
* 다양한 화면 크기에서 레이아웃이 올바르게 작동하는지
* 사용자 입장에서 사용하기에 불편한 부분이 있는지