### PR TITLE
Feat: 일정 추천 탭 날짜 구간 선택 기능 구현 및 반응형 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "lucide-react": "^0.542.0",
         "prettier": "^3.6.2",
         "react": "^19.1.1",
+        "react-day-picker": "^9.10.0",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.2",
         "tailwind-merge": "^3.3.1",
@@ -353,6 +354,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.9",
@@ -2604,6 +2611,22 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
+    },
     "node_modules/debounce": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
@@ -4215,6 +4238,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.10.0.tgz",
+      "integrity": "sha512-tedecLSd+fpSN+J08601MaMsf122nxtqZXxB6lwX37qFoLtuPNuRJN8ylxFjLhyJS1kaLfAqL1GUkSLd2BMrpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "^4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lucide-react": "^0.542.0",
     "prettier": "^3.6.2",
     "react": "^19.1.1",
+    "react-day-picker": "^9.10.0",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.2",
     "tailwind-merge": "^3.3.1",

--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -67,7 +67,7 @@ const Button = ({
           {icon}
         </span>
       )}
-      <span className="flex items-center">{text}</span>
+      <span className="flex-1 text-center">{text}</span>
       {icon && iconPosition === 'right' && (
         <span className={`${iconSizes[size]} flex items-center justify-center flex-shrink-0`}>
           {icon}

--- a/src/pages/TeamCalendar/components/RecommendTimes.tsx
+++ b/src/pages/TeamCalendar/components/RecommendTimes.tsx
@@ -31,23 +31,31 @@ const RecommendTimes: React.FC = () => {
           onChange={setSelectedDuration}
           options={timeOptions}
         />
-        <div className="space-y-3">
-          {mockTimeSlots.map((slot) => (
-            <div className="border border-gray-200 rounded-lg p-3">
-              <div className="flex justify-between items-center">
-                <div className="font-medium text-gray-800">{slot.day}</div>
-                <span
-                  className={`px-2 py-1 text-xs font-medium rounded-full ${
-                    slot.tag === '최적' ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-700'
-                  }`}
-                >
-                  {slot.tag}
-                </span>
-              </div>
-              <div className="text-sm text-gray-700 mt-2 font-medium">{slot.time}</div>
-              <div className="text-xs text-gray-500 mt-1">{slot.participants}</div>
+        <div className="flex flex-col">
+          {/*날짜 기간 선택*/}
+          <div className="mb-3">
+            <div className="border border-gray-200 p-4 rounded-lg">
+              <SelectDurationCalendar range={range} setRange={setRange} onSearch={handleSearch} />
             </div>
-          ))}
+          </div>
+          <div className="space-y-3">
+            {mockTimeSlots.map((slot) => (
+              <div className="border border-gray-200 rounded-lg p-3">
+                <div className="flex justify-between items-center">
+                  <div className="font-medium text-gray-800">{slot.day}</div>
+                  <span
+                    className={`px-2 py-1 text-xs font-medium rounded-full ${
+                      slot.tag === '최적' ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-700'
+                    }`}
+                  >
+                    {slot.tag}
+                  </span>
+                </div>
+                <div className="text-sm text-gray-700 mt-2 font-medium">{slot.time}</div>
+                <div className="text-xs text-gray-500 mt-1">{slot.participants}</div>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
 

--- a/src/pages/TeamCalendar/components/RecommendTimes.tsx
+++ b/src/pages/TeamCalendar/components/RecommendTimes.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import type { DateRange } from 'react-day-picker';
 import '@/styles/datapicker.css';
 import { mockTimeSlots } from '@/mockdata/teamData';
-import TimeBox from '@/components/atoms/SelectBox';
+import SelectBox from '@/components/atoms/SelectBox';
 import Button from '@/components/atoms/Button';
 import { generateTimeOptions } from '@/utils/timeUtils';
 import SelectDurationCalendar from '@/pages/TeamCalendar/components/SelectDurationCalendar';
@@ -11,6 +11,7 @@ const RecommendTimes: React.FC = () => {
   const [selectedDuration, setSelectedDuration] = useState(60);
   const timeOptions = generateTimeOptions(4);
   const [range, setRange] = useState<DateRange | undefined>();
+  const [showDatePicker, setShowDatePicker] = useState(false);
 
   const handleSearch = () => {
     if (!range?.from || !range?.to) {
@@ -20,48 +21,100 @@ const RecommendTimes: React.FC = () => {
     alert(`선택된 기간: ${range.from.toDateString()} ~ ${range.to.toDateString()}`);
   };
 
+  // 모든 뷰에서 사용되는 공통 컴포넌트
+  const DatePickerSection = ({ forceShow = false }: { forceShow?: boolean }) => (
+    <>
+      {!forceShow && (
+        <Button
+          onClick={() => setShowDatePicker(!showDatePicker)}
+          text={showDatePicker ? '날짜 선택 숨기기' : '날짜 선택하기'}
+          variant="secondary"
+          fullWidth={true}
+          className="mb-3"
+        />
+      )}
+      {(showDatePicker || forceShow) && (
+        <div className="border border-gray-200 p-4 rounded-lg">
+          <SelectDurationCalendar range={range} setRange={setRange} onSearch={handleSearch} />
+        </div>
+      )}
+    </>
+  );
+
+  const TimeSlotCards = ({ isDesktop = false }: { isDesktop?: boolean }) => (
+    <div
+      className={
+        isDesktop
+          ? 'space-y-3'
+          : 'w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2 gap-2 sm:gap-3 lg:gap-4 transition-all duration-300 ease-out'
+      }
+    >
+      {mockTimeSlots.slice(0, 4).map((slot, index) => (
+        <div
+          key={slot.id}
+          className={
+            isDesktop
+              ? 'border border-gray-200 rounded-lg p-3'
+              : 'min-w-0 bg-white border border-gray-200 rounded-lg p-2 sm:p-3 transform transition-all duration-300 ease-out min-w-0'
+          }
+          style={!isDesktop ? { transitionDelay: `${index * 50}ms` } : undefined}
+        >
+          <div className="flex justify-between items-center gap-2">
+            <div className={`font-medium text-gray-800 ${!isDesktop ? 'flex-1 min-w-0' : ''}`}>
+              {slot.day}
+            </div>
+            <span
+              className={`${
+                isDesktop
+                  ? 'px-2 py-1 text-xs font-medium rounded-full'
+                  : 'px-1 py-0.5 sm:px-1.5 sm:py-0.5 lg:px-2 lg:py-1 text-xs font-medium rounded-full transition-all duration-200 flex-shrink-0'
+              } ${slot.tag === '최적' ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-700'}`}
+            >
+              {slot.tag}
+            </span>
+          </div>
+          <div
+            className={`text-gray-700 font-medium ${isDesktop ? 'text-sm mt-2' : 'text-xs mt-1 sm:mt-2'}`}
+          >
+            {slot.time}
+          </div>
+          <div
+            className={`text-gray-500 ${isDesktop ? 'text-xs mt-1' : 'text-xs mt-1 line-clamp-2'}`}
+          >
+            {slot.participants}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+
   return (
     <div className="w-full bg-white overflow-hidden p-6 rounded-xl border shadow-lg border-mainBlue/70">
       <h2 className="text-lg font-semibold text-gray-800 mb-4">가장 빠른 팀 일정 추천</h2>
 
+      {/* 데스크탑 뷰 */}
       <div className="xl:block hidden">
-        <TimeBox
+        <SelectBox
           label="최소 요구 시간"
           value={selectedDuration}
           onChange={setSelectedDuration}
           options={timeOptions}
         />
         <div className="flex flex-col">
-          {/*날짜 기간 선택*/}
           <div className="mb-3">
-            <div className="border border-gray-200 p-4 rounded-lg">
-              <SelectDurationCalendar range={range} setRange={setRange} onSearch={handleSearch} />
-            </div>
+            <DatePickerSection />
           </div>
-          <div className="space-y-3">
-            {mockTimeSlots.map((slot) => (
-              <div className="border border-gray-200 rounded-lg p-3">
-                <div className="flex justify-between items-center">
-                  <div className="font-medium text-gray-800">{slot.day}</div>
-                  <span
-                    className={`px-2 py-1 text-xs font-medium rounded-full ${
-                      slot.tag === '최적' ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-700'
-                    }`}
-                  >
-                    {slot.tag}
-                  </span>
-                </div>
-                <div className="text-sm text-gray-700 mt-2 font-medium">{slot.time}</div>
-                <div className="text-xs text-gray-500 mt-1">{slot.participants}</div>
-              </div>
-            ))}
+          <TimeSlotCards isDesktop={true} />
+          <div className="mt-4">
+            <Button onClick={() => {}} text="더 많은 시간 확인하기" fullWidth={true} />
           </div>
         </div>
       </div>
 
+      {/* 모바일/태블릿 뷰 */}
       <div className="xl:hidden block">
         <div className="mb-4">
-          <TimeBox
+          <SelectBox
             label="최소 요구 시간"
             value={selectedDuration}
             onChange={setSelectedDuration}
@@ -70,43 +123,19 @@ const RecommendTimes: React.FC = () => {
           />
         </div>
 
-        {/* 반응형 레이아웃: 작은 화면에서는 세로, 큰 화면에서는 가로 */}
         <div className="flex flex-col lg:flex-row lg:gap-6">
-          {/*날짜 기간 선택*/}
           <div className="lg:w-1/2 mb-3 lg:mb-0">
-            <div className="border border-gray-200 p-4 rounded-lg">
-              <SelectDurationCalendar range={range} setRange={setRange} onSearch={handleSearch} />
+            {/* 모바일: 토글 버튼 O, 태블릿: datepicker 항상 표시 , 데스크탑: 토글 버튼 O */}
+            <div className="lg:hidden">
+              <DatePickerSection forceShow={false} />
+            </div>
+            <div className="hidden lg:block xl:hidden">
+              <DatePickerSection forceShow={true} />
             </div>
           </div>
 
-          {/* 반응형 카드 레이아웃 */}
           <div className="lg:w-1/2 mt-1">
-            <div className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2 gap-2 sm:gap-3 lg:gap-4 transition-all duration-300 ease-out">
-              {/* 4개까지만 화면에 띄움 */}
-              {mockTimeSlots.slice(0, 4).map((slot, index) => (
-                <div
-                  key={slot.id}
-                  className="min-w-0 bg-white border border-gray-200 rounded-lg p-2 sm:p-3 transform transition-all duration-300 ease-out min-w-0"
-                  style={{
-                    transitionDelay: `${index * 50}ms`,
-                  }}
-                >
-                  <div className="flex justify-between items-center gap-2">
-                    <div className="font-medium text-gray-800 flex-1 min-w-0">{slot.day}</div>
-                    <span
-                      className={`px-1 py-0.5 sm:px-1.5 sm:py-0.5 lg:px-2 lg:py-1 text-xs font-medium rounded-full transition-all duration-200 flex-shrink-0 ${
-                        slot.tag === '최적' ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-700'
-                      }`}
-                    >
-                      {slot.tag}
-                    </span>
-                  </div>
-                  <div className="text-xs text-gray-700 mt-1 sm:mt-2 font-medium">{slot.time}</div>
-                  <div className="text-xs text-gray-500 mt-1 line-clamp-2">{slot.participants}</div>
-                </div>
-              ))}
-            </div>
-
+            <TimeSlotCards />
             <div className="mt-4 sm:mt-6">
               <Button onClick={() => {}} text="더 많은 시간 확인하기" fullWidth={true} />
             </div>

--- a/src/pages/TeamCalendar/components/RecommendTimes.tsx
+++ b/src/pages/TeamCalendar/components/RecommendTimes.tsx
@@ -62,7 +62,9 @@ const RecommendTimes: React.FC = () => {
           />
         </div>
         {/*날짜 기간 선택*/}
-        <SelectDurationCalendar range={range} setRange={setRange} onSearch={handleSearch} />
+        <div className="border border-gray-200 p-4 rounded-lg mb-3">
+          <SelectDurationCalendar range={range} setRange={setRange} onSearch={handleSearch} />
+        </div>
         {/* 반응형 카드 레이아웃 */}
         <div className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 sm:gap-3 lg:gap-4 transition-all duration-300 ease-out">
           {mockTimeSlots.map((slot, index) => (

--- a/src/pages/TeamCalendar/components/RecommendTimes.tsx
+++ b/src/pages/TeamCalendar/components/RecommendTimes.tsx
@@ -1,12 +1,24 @@
 import React, { useState } from 'react';
+import type { DateRange } from 'react-day-picker';
+import '@/styles/datapicker.css';
 import { mockTimeSlots } from '@/mockdata/teamData';
 import TimeBox from '@/components/atoms/SelectBox';
 import Button from '@/components/atoms/Button';
 import { generateTimeOptions } from '@/utils/timeUtils';
+import SelectDurationCalendar from '@/pages/TeamCalendar/components/SelectDurationCalendar';
 
 const RecommendTimes: React.FC = () => {
   const [selectedDuration, setSelectedDuration] = useState(60);
   const timeOptions = generateTimeOptions(4);
+  const [range, setRange] = useState<DateRange | undefined>();
+
+  const handleSearch = () => {
+    if (!range?.from || !range?.to) {
+      alert('날짜 범위를 선택해주세요!');
+      return;
+    }
+    alert(`선택된 기간: ${range.from.toDateString()} ~ ${range.to.toDateString()}`);
+  };
 
   return (
     <div className="w-full bg-white overflow-hidden p-6 rounded-xl border shadow-lg border-mainBlue/70">
@@ -19,7 +31,6 @@ const RecommendTimes: React.FC = () => {
           onChange={setSelectedDuration}
           options={timeOptions}
         />
-
         <div className="space-y-3">
           {mockTimeSlots.map((slot) => (
             <div className="border border-gray-200 rounded-lg p-3">
@@ -50,7 +61,8 @@ const RecommendTimes: React.FC = () => {
             className="mb-4"
           />
         </div>
-
+        {/*날짜 기간 선택*/}
+        <SelectDurationCalendar range={range} setRange={setRange} onSearch={handleSearch} />
         {/* 반응형 카드 레이아웃 */}
         <div className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 sm:gap-3 lg:gap-4 transition-all duration-300 ease-out">
           {mockTimeSlots.map((slot, index) => (

--- a/src/pages/TeamCalendar/components/RecommendTimes.tsx
+++ b/src/pages/TeamCalendar/components/RecommendTimes.tsx
@@ -61,39 +61,49 @@ const RecommendTimes: React.FC = () => {
             className="mb-4"
           />
         </div>
-        {/*날짜 기간 선택*/}
-        <div className="border border-gray-200 p-4 rounded-lg mb-3">
-          <SelectDurationCalendar range={range} setRange={setRange} onSearch={handleSearch} />
-        </div>
-        {/* 반응형 카드 레이아웃 */}
-        <div className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 sm:gap-3 lg:gap-4 transition-all duration-300 ease-out">
-          {mockTimeSlots.map((slot, index) => (
-            <div
-              key={slot.id}
-              className="min-w-0 bg-white border border-gray-200 rounded-lg p-2 sm:p-3 transform transition-all duration-300 ease-out min-w-0"
-              style={{
-                transitionDelay: `${index * 50}ms`,
-              }}
-            >
-              <div className="flex justify-between items-center gap-2">
-                <div className="font-medium text-gray-800 flex-1 min-w-0">{slot.day}</div>
-                <span
-                  className={`px-1 py-0.5 sm:px-1.5 sm:py-0.5 lg:px-2 lg:py-1 text-xs font-medium rounded-full transition-all duration-200 flex-shrink-0 ${
-                    slot.tag === '최적' ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-700'
-                  }`}
-                >
-                  {slot.tag}
-                </span>
-              </div>
-              <div className="text-xs text-gray-700 mt-1 sm:mt-2 font-medium">{slot.time}</div>
-              <div className="text-xs text-gray-500 mt-1 line-clamp-2">{slot.participants}</div>
-            </div>
-          ))}
-        </div>
-      </div>
 
-      <div className="mt-4 sm:mt-6">
-        <Button onClick={() => {}} text="더 많은 시간 확인하기" fullWidth={true} />
+        {/* 반응형 레이아웃: 작은 화면에서는 세로, 큰 화면에서는 가로 */}
+        <div className="flex flex-col lg:flex-row lg:gap-6">
+          {/*날짜 기간 선택*/}
+          <div className="lg:w-1/2 mb-3 lg:mb-0">
+            <div className="border border-gray-200 p-4 rounded-lg">
+              <SelectDurationCalendar range={range} setRange={setRange} onSearch={handleSearch} />
+            </div>
+          </div>
+
+          {/* 반응형 카드 레이아웃 */}
+          <div className="lg:w-1/2 mt-1">
+            <div className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2 gap-2 sm:gap-3 lg:gap-4 transition-all duration-300 ease-out">
+              {/* 4개까지만 화면에 띄움 */}
+              {mockTimeSlots.slice(0, 4).map((slot, index) => (
+                <div
+                  key={slot.id}
+                  className="min-w-0 bg-white border border-gray-200 rounded-lg p-2 sm:p-3 transform transition-all duration-300 ease-out min-w-0"
+                  style={{
+                    transitionDelay: `${index * 50}ms`,
+                  }}
+                >
+                  <div className="flex justify-between items-center gap-2">
+                    <div className="font-medium text-gray-800 flex-1 min-w-0">{slot.day}</div>
+                    <span
+                      className={`px-1 py-0.5 sm:px-1.5 sm:py-0.5 lg:px-2 lg:py-1 text-xs font-medium rounded-full transition-all duration-200 flex-shrink-0 ${
+                        slot.tag === '최적' ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-700'
+                      }`}
+                    >
+                      {slot.tag}
+                    </span>
+                  </div>
+                  <div className="text-xs text-gray-700 mt-1 sm:mt-2 font-medium">{slot.time}</div>
+                  <div className="text-xs text-gray-500 mt-1 line-clamp-2">{slot.participants}</div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-4 sm:mt-6">
+              <Button onClick={() => {}} text="더 많은 시간 확인하기" fullWidth={true} />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/TeamCalendar/components/SelectDurationCalendar.tsx
+++ b/src/pages/TeamCalendar/components/SelectDurationCalendar.tsx
@@ -1,0 +1,70 @@
+import { DayPicker, useDayPicker } from 'react-day-picker';
+import type { DateRange, MonthCaptionProps } from 'react-day-picker';
+import 'react-day-picker/dist/style.css';
+import { ko } from 'date-fns/locale';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import Button from '@/components/atoms/Button';
+
+interface Props {
+  range: DateRange | undefined;
+  setRange: (range: DateRange | undefined) => void;
+  onSearch: () => void;
+}
+
+// 커스텀 캡션 컴포넌트
+function CustomCaption(props: MonthCaptionProps) {
+  const { goToMonth, nextMonth, previousMonth } = useDayPicker();
+  const { calendarMonth } = props;
+
+  return (
+    <div className="flex items-center justify-between px-4 mb-2">
+      <button
+        onClick={() => previousMonth && goToMonth(previousMonth)}
+        disabled={!previousMonth}
+        className="bg-transparent border-none cursor-pointer hover:bg-gray-100 p-2 rounded disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
+      >
+        <ChevronLeft className="w-5 h-5 text-gray-600" />
+      </button>
+
+      <span className="text-base">
+        {calendarMonth.date.toLocaleString('ko-KR', {
+          year: 'numeric',
+          month: 'long',
+        })}
+      </span>
+
+      <button
+        onClick={() => nextMonth && goToMonth(nextMonth)}
+        disabled={!nextMonth}
+        className="bg-transparent border-none cursor-pointer hover:bg-gray-100 p-2 rounded disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
+      >
+        <ChevronRight className="w-5 h-5 text-gray-600" />
+      </button>
+    </div>
+  );
+}
+
+const SelectDurationCalendar: React.FC<Props> = ({ range, setRange, onSearch }) => {
+  return (
+    <div className="date-picker">
+      <DayPicker
+        mode="range"
+        selected={range}
+        onSelect={setRange}
+        locale={ko} // 한국어 요일 헤더
+        components={{
+          MonthCaption: CustomCaption, // 커스텀 캡션 사용
+        }}
+        classNames={{
+          range_start: 'bg-blue-500 text-white rounded-lg transition-all',
+          range_end: 'bg-blue-500 text-white rounded-lg transition-all',
+          range_middle: 'bg-blue-50 transition-colors duration-200',
+          selected: 'text-black transition-colors duration-200',
+          today: 'text-black underline underline-offset-4',
+        }}
+      />
+    </div>
+  );
+};
+
+export default SelectDurationCalendar;

--- a/src/pages/TeamCalendar/components/SelectDurationCalendar.tsx
+++ b/src/pages/TeamCalendar/components/SelectDurationCalendar.tsx
@@ -63,6 +63,36 @@ const SelectDurationCalendar: React.FC<Props> = ({ range, setRange, onSearch }) 
           today: 'text-black underline underline-offset-4',
         }}
       />
+
+      <div className="mt-6 space-y-4">
+        {/* 선택된 날짜 표시 */}
+        <div className="flex items-center gap-3">
+          <div className="flex-1 bg-gray-50 border border-gray-200 rounded-lg p-3 text-center">
+            <div className="text-xs text-gray-500 mb-1">시작일</div>
+            <div className="text-sm font-medium text-gray-800">
+              {range?.from ? range.from.toLocaleDateString('ko-KR') : '날짜 선택'}
+            </div>
+          </div>
+
+          <div className="text-gray-400">→</div>
+
+          <div className="flex-1 bg-gray-50 border border-gray-200 rounded-lg p-3 text-center">
+            <div className="text-xs text-gray-500 mb-1">종료일</div>
+            <div className="text-sm font-medium text-gray-800">
+              {range?.to ? range.to.toLocaleDateString('ko-KR') : '날짜 선택'}
+            </div>
+          </div>
+        </div>
+
+        {/* 검색 버튼 */}
+        <Button
+          onClick={range?.from && range?.to ? onSearch : () => {}}
+          text="일정 검색하기"
+          fullWidth={true}
+          variant={range?.from && range?.to ? 'primary' : 'secondary'}
+          className={`${!range?.from || !range?.to ? 'cursor-not-allowed opacity-50' : ''}`}
+        />
+      </div>
     </div>
   );
 };

--- a/src/pages/TeamCalendar/components/SelectDurationCalendar.tsx
+++ b/src/pages/TeamCalendar/components/SelectDurationCalendar.tsx
@@ -17,16 +17,16 @@ function CustomCaption(props: MonthCaptionProps) {
   const { calendarMonth } = props;
 
   return (
-    <div className="flex items-center justify-between px-4 mb-2">
+    <div className="flex items-center justify-between px-2 sm:px-4 mb-2 sm:mb-4">
       <button
         onClick={() => previousMonth && goToMonth(previousMonth)}
         disabled={!previousMonth}
-        className="bg-transparent border-none cursor-pointer hover:bg-gray-100 p-2 rounded disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
+        className="bg-transparent border-none cursor-pointer hover:bg-gray-100 p-1 sm:p-2 rounded disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
       >
-        <ChevronLeft className="w-5 h-5 text-gray-600" />
+        <ChevronLeft className="w-4 h-4 sm:w-5 sm:h-5 text-gray-600" />
       </button>
 
-      <span className="text-base">
+      <span className="text-sm sm:text-base md:text-lg font-medium text-gray-800">
         {calendarMonth.date.toLocaleString('ko-KR', {
           year: 'numeric',
           month: 'long',
@@ -36,9 +36,9 @@ function CustomCaption(props: MonthCaptionProps) {
       <button
         onClick={() => nextMonth && goToMonth(nextMonth)}
         disabled={!nextMonth}
-        className="bg-transparent border-none cursor-pointer hover:bg-gray-100 p-2 rounded disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
+        className="bg-transparent border-none cursor-pointer hover:bg-gray-100 p-1 sm:p-2 rounded disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
       >
-        <ChevronRight className="w-5 h-5 text-gray-600" />
+        <ChevronRight className="w-4 h-4 sm:w-5 sm:h-5 text-gray-600" />
       </button>
     </div>
   );
@@ -47,51 +47,62 @@ function CustomCaption(props: MonthCaptionProps) {
 const SelectDurationCalendar: React.FC<Props> = ({ range, setRange, onSearch }) => {
   return (
     <div className="date-picker">
-      <DayPicker
-        mode="range"
-        selected={range}
-        onSelect={setRange}
-        locale={ko} // 한국어 요일 헤더
-        components={{
-          MonthCaption: CustomCaption, // 커스텀 캡션 사용
-        }}
-        classNames={{
-          range_start: 'bg-blue-500 text-white rounded-lg transition-all',
-          range_end: 'bg-blue-500 text-white rounded-lg transition-all',
-          range_middle: 'bg-blue-50 transition-colors duration-200',
-          selected: 'text-black transition-colors duration-200',
-          today: 'text-black underline underline-offset-4',
-        }}
-      />
-
-      <div className="mt-6 space-y-4">
-        {/* 선택된 날짜 표시 */}
-        <div className="flex items-center gap-3">
-          <div className="flex-1 bg-gray-50 border border-gray-200 rounded-lg p-3 text-center">
-            <div className="text-xs text-gray-500 mb-1">시작일</div>
-            <div className="text-sm font-medium text-gray-800">
-              {range?.from ? range.from.toLocaleDateString('ko-KR') : '날짜 선택'}
-            </div>
-          </div>
-
-          <div className="text-gray-400">→</div>
-
-          <div className="flex-1 bg-gray-50 border border-gray-200 rounded-lg p-3 text-center">
-            <div className="text-xs text-gray-500 mb-1">종료일</div>
-            <div className="text-sm font-medium text-gray-800">
-              {range?.to ? range.to.toLocaleDateString('ko-KR') : '날짜 선택'}
-            </div>
-          </div>
+      {/* 캘린더 컨테이너 */}
+      <div className="bg-white rounded-lg p-4">
+        <div className="flex justify-center">
+          <DayPicker
+            mode="range"
+            selected={range}
+            onSelect={setRange}
+            locale={ko} // 한국어 요일 헤더
+            components={{
+              MonthCaption: CustomCaption, // 커스텀 캡션 사용
+            }}
+            classNames={{
+              range_start: 'bg-blue-500 text-white rounded-lg transition-all',
+              range_end: 'bg-blue-500 text-white rounded-lg transition-all',
+              range_middle: 'bg-blue-50 transition-colors duration-200',
+              selected: 'text-black transition-colors duration-200',
+              today: 'text-black underline underline-offset-4',
+            }}
+          />
         </div>
 
-        {/* 검색 버튼 */}
-        <Button
-          onClick={range?.from && range?.to ? onSearch : () => {}}
-          text="일정 검색하기"
-          fullWidth={true}
-          variant={range?.from && range?.to ? 'primary' : 'secondary'}
-          className={`${!range?.from || !range?.to ? 'cursor-not-allowed opacity-50' : ''}`}
-        />
+        {/* 선택된 날짜 표시 - 반응형 */}
+        <div className="mt-4 sm:mt-6 space-y-3 sm:space-y-4 w-full">
+          {/* 시작일 & 종료일 버튼 : 세로 배치 -> 가로 배치 */}
+          <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
+            <div className="flex-1 bg-gray-50 border border-gray-200 rounded-lg p-2 sm:p-3 text-center">
+              <div className="text-xs text-gray-500 mb-1">시작일</div>
+              <div className="text-sm sm:text-base font-medium text-gray-800">
+                {range?.from ? range.from.toLocaleDateString('ko-KR') : '날짜 선택'}
+              </div>
+            </div>
+
+            {/* 화살표 : 아래쪽 -> 오른쪽 */}
+            <div className="text-gray-400 text-center sm:text-left">
+              <span className="sm:hidden">↓</span>
+              <span className="hidden sm:inline">→</span>
+            </div>
+
+            <div className="flex-1 bg-gray-50 border border-gray-200 rounded-lg p-2 sm:p-3 text-center">
+              <div className="text-xs text-gray-500 mb-1">종료일</div>
+              <div className="text-sm sm:text-base font-medium text-gray-800">
+                {range?.to ? range.to.toLocaleDateString('ko-KR') : '날짜 선택'}
+              </div>
+            </div>
+          </div>
+
+          {/* 검색 버튼 */}
+          <Button
+            onClick={range?.from && range?.to ? onSearch : () => {}}
+            text="일정 검색하기"
+            fullWidth={true}
+            variant={range?.from && range?.to ? 'primary' : 'secondary'}
+            size="md"
+            className={`${!range?.from || !range?.to ? 'cursor-not-allowed opacity-50' : ''}`}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/TeamCalendar/index.tsx
+++ b/src/pages/TeamCalendar/index.tsx
@@ -36,7 +36,7 @@ const TeamCalendarPage = () => {
             <UpcomingTeamSchedule />
           </Drawer>
 
-          <div className="flex flex-col">
+          <div className="flex flex-col flex-1">
             <div className="overflow-x-auto order-b border-gray-200">
               <div className="p-2 rounded-lg border border-gray-100">
                 <RecommendTimes />

--- a/src/pages/TeamCalendar/index.tsx
+++ b/src/pages/TeamCalendar/index.tsx
@@ -10,7 +10,7 @@ const TeamCalendarPage = () => {
   const [isTeamListModalOpen, setIsTeamListModalOpen] = useState(false);
 
   return (
-    <div className="min-h-[calc(100vh-70px)] flex">
+    <div className="min-h-[calc(100vh-70px)]">
       <div className="hidden transition-all duration-500 uration-500 ease-in-out bg-gradient-to-br from-blue-50 to-indigo-100 ease-in-out xl:flex">
         <Drawer>
           <TeamMembers onSettingsClick={() => setIsTeamListModalOpen(true)} />
@@ -21,7 +21,7 @@ const TeamCalendarPage = () => {
           <FullCalendar />
         </div>
 
-        <div className="pr-4 pt-2 pl-2 w-80 transition-all duration-500 ease-in-out transform">
+        <div className="pr-4 pt-2 pl-2 w-[400px] transition-all duration-500 ease-in-out transform">
           <div className="transition-all duration-300 ease-out transform">
             <RecommendTimes />
           </div>
@@ -36,7 +36,7 @@ const TeamCalendarPage = () => {
             <UpcomingTeamSchedule />
           </Drawer>
 
-          <div className="flex flex-col flex-1">
+          <div className="flex flex-col">
             <div className="overflow-x-auto order-b border-gray-200">
               <div className="p-2 rounded-lg border border-gray-100">
                 <RecommendTimes />

--- a/src/pages/TeamCalendar/index.tsx
+++ b/src/pages/TeamCalendar/index.tsx
@@ -21,7 +21,7 @@ const TeamCalendarPage = () => {
           <FullCalendar />
         </div>
 
-        <div className="pr-4 pt-2 pl-2 w-[400px] transition-all duration-500 ease-in-out transform">
+        <div className="px-2 py-2 pr-4 w-[400px] transition-all duration-500 ease-in-out transform">
           <div className="transition-all duration-300 ease-out transform">
             <RecommendTimes />
           </div>

--- a/src/pages/TeamCalendar/index.tsx
+++ b/src/pages/TeamCalendar/index.tsx
@@ -10,8 +10,8 @@ const TeamCalendarPage = () => {
   const [isTeamListModalOpen, setIsTeamListModalOpen] = useState(false);
 
   return (
-    <div className="min-h-[calc(100vh-70px)]">
-      <div className="hidden transition-all duration-500 uration-500 ease-in-out bg-gradient-to-br from-blue-50 to-indigo-100 ease-in-out xl:flex">
+    <div className="min-h-[calc(100vh-70px)] bg-gradient-to-br from-blue-50 to-indigo-100">
+      <div className="hidden transition-all duration-500 duration-500 ease-in-out ease-in-out xl:flex">
         <Drawer>
           <TeamMembers onSettingsClick={() => setIsTeamListModalOpen(true)} />
           <UpcomingTeamSchedule />

--- a/src/styles/datapicker.css
+++ b/src/styles/datapicker.css
@@ -1,0 +1,11 @@
+/* 캘린더 양쪽 버튼 숨기기 */
+.date-picker .rdp-button_previous,
+.date-picker .rdp-button_next {
+  display: none;
+}
+
+/* 월 캡션 영역 정리 */
+.date-picker .rdp-month_caption {
+  margin: 0;
+  padding: 0;
+}


### PR DESCRIPTION
# 📝 PR 설명

## 변경 사항

- 일정 추천 탭의 날짜 구간 선택 기능을 구현하였습니다.
- 일정 추천 탭의 날짜 구간 선택에 토글 기능을 추가하였습니다.
- 일정 추천 탭의 반응형 동작을 구현하였습니다.

## 상세 설명

[날짜 구간 선택 UI - 모바일]

<img width="354" height="603" alt="스크린샷 2025-09-18 오전 12 26 24" src="https://github.com/user-attachments/assets/203a33b6-654c-4bfa-8197-7c70f416187f" />

[날짜 구간 선택 UI - 태블릿]

<img width="1066" height="742" alt="스크린샷 2025-09-18 오전 3 58 05" src="https://github.com/user-attachments/assets/48a3874d-e8a7-49e1-8322-a107959567bd" />

[날짜 구간 선택 UI - 데스트탑]

<img width="1708" height="852" alt="스크린샷 2025-09-18 오전 3 58 50" src="https://github.com/user-attachments/assets/c86829d5-499d-4347-87ee-3172c1fd5e20" />

[토글기능 - 버튼으로 구현]

<img width="410" height="786" alt="스크린샷 2025-09-18 오전 4 00 02" src="https://github.com/user-attachments/assets/824c1d28-263d-4543-9f1c-281e50f10eb6" />


## 리뷰 해야할 부분
- 다양한 화면 크기에서 레이아웃이 올바르게 작동하는지
- 사용자 입장에서 사용하기에 불편한 부분이 있는지

## 추가 논의 사항
- 현재 데스크탑 뷰에서 "날짜 선택하기" 버튼을 누르면 오른쪽 사이드바가 매우 길어집니다. 이에 따라 세로 스크롤이 자동으로 생기게 되는데, 동시에 왼쪽의 드로어가 잘린 듯한 형태가 됩니다. 드로어 세로 길이를 어떻게 맞추면 좋을지 논의가 필요합니다.

<img width="1384" height="893" alt="스크린샷 2025-09-18 오전 4 03 22" src="https://github.com/user-attachments/assets/f6122865-e6ef-4693-8d51-7ebab7b0daaa" />

<img width="1386" height="887" alt="스크린샷 2025-09-18 오전 4 03 34" src="https://github.com/user-attachments/assets/0e0d8582-2018-4c65-9deb-747dfde71a4a" />

