### PR TITLE
Feat: 시간표 등록 모달 에브리타임 url / 이미지 파싱 api 연동

### DIFF
--- a/src/apis/client/apiClients.ts
+++ b/src/apis/client/apiClients.ts
@@ -3,7 +3,7 @@ import { API_BASE_URL } from '@/apis/constants/endpoints';
 
 export const apiClient = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 30000,
+  timeout: 100000,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/apis/constants/endpoints.ts
+++ b/src/apis/constants/endpoints.ts
@@ -5,3 +5,7 @@ export const AUTH_ENDPOINTS = {
   LOGIN: '/api/members/login',
   REFRESH: '/api/members/refresh',
 } as const;
+
+export const EVERYTIME_ENDPOINTS = {
+  TIMETABLES: '/api/everytime/timetables',
+} as const;

--- a/src/apis/constants/endpoints.ts
+++ b/src/apis/constants/endpoints.ts
@@ -8,4 +8,5 @@ export const AUTH_ENDPOINTS = {
 
 export const EVERYTIME_ENDPOINTS = {
   TIMETABLES: '/api/everytime/timetables',
+  TIMETABLE_DETAIL: '/api/everytime/timetable',
 } as const;

--- a/src/apis/constants/endpoints.ts
+++ b/src/apis/constants/endpoints.ts
@@ -9,4 +9,5 @@ export const AUTH_ENDPOINTS = {
 export const EVERYTIME_ENDPOINTS = {
   TIMETABLES: '/api/everytime/timetables',
   TIMETABLE_DETAIL: '/api/everytime/timetable',
+  TIMETABLE_IMAGE: '/api/everytime/timetable',
 } as const;

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,4 +1,6 @@
 export { apiClient } from '@/apis/client/apiClients';
 export { authAPI } from '@/apis/services/auth';
+export { everytimeAPI } from '@/apis/services/everytime';
 export type * from '@/apis/types/auth';
-export { AUTH_ENDPOINTS, API_BASE_URL } from '@/apis/constants/endpoints';
+export type * from '@/apis/types/timetable';
+export { API_BASE_URL, AUTH_ENDPOINTS, EVERYTIME_ENDPOINTS } from '@/apis/constants/endpoints';

--- a/src/apis/services/everytime.ts
+++ b/src/apis/services/everytime.ts
@@ -1,0 +1,26 @@
+import { apiClient } from '@/apis/client/apiClients';
+import { EVERYTIME_ENDPOINTS } from '@/apis/constants/endpoints';
+import type { TimetableListRequest, TimetableListResponse } from '@/apis/types/timetable';
+
+export const everytimeAPI = {
+  getTimetables: (request: TimetableListRequest) => {
+    return apiClient
+      .get(EVERYTIME_ENDPOINTS.TIMETABLES, {
+        params: { url: request.url },
+      })
+      .then((response) => {
+        console.log('시간표 목록 조회 성공', response.data);
+        return response.data as TimetableListResponse;
+      })
+      .catch((error) => {
+        console.error('시간표 목록 조회 에러:', error);
+        console.error('에러 상세:', {
+          message: error.message,
+          code: error.code,
+          status: error.response?.status,
+          data: error.response?.data,
+        });
+        throw error;
+      });
+  },
+};

--- a/src/apis/services/everytime.ts
+++ b/src/apis/services/everytime.ts
@@ -38,9 +38,27 @@ export const everytimeAPI = {
       })
       .then((response) => {
         console.log('시간표 상세 조회 성공', response.data);
-        return response.data as TimetableDetailResponse;
+        const data = response.data as TimetableDetailResponse;
+
+        // 빈 시간표인 경우 빈 배열로 처리
+        if (!data.subjects || data.subjects.length === 0) {
+          return {
+            ...data,
+            subjects: [],
+          };
+        }
+
+        return data;
       })
       .catch((error) => {
+        //403 에러 - 빈 시간표의 경우를 예외처리
+        if (error.response?.status === 403) {
+          return {
+            year: '',
+            semester: '',
+            subjects: [],
+          };
+        }
         console.error('시간표 상세 조회 에러:', error);
         console.error('에러 상세:', {
           message: error.message,

--- a/src/apis/services/everytime.ts
+++ b/src/apis/services/everytime.ts
@@ -1,8 +1,14 @@
 import { apiClient } from '@/apis/client/apiClients';
 import { EVERYTIME_ENDPOINTS } from '@/apis/constants/endpoints';
-import type { TimetableListRequest, TimetableListResponse } from '@/apis/types/timetable';
+import type {
+  TimetableListRequest,
+  TimetableListResponse,
+  TimetableDetailRequest,
+  TimetableDetailResponse,
+} from '@/apis/types/timetable';
 
 export const everytimeAPI = {
+  //시간표 목록 조회
   getTimetables: (request: TimetableListRequest) => {
     return apiClient
       .get(EVERYTIME_ENDPOINTS.TIMETABLES, {
@@ -17,6 +23,27 @@ export const everytimeAPI = {
         console.error('에러 상세:', {
           message: error.message,
           code: error.code,
+          status: error.response?.status,
+          data: error.response?.data,
+        });
+        throw error;
+      });
+  },
+
+  //시간표 상세 조회
+  getTimetableDetail: (request: TimetableDetailRequest) => {
+    return apiClient
+      .get(EVERYTIME_ENDPOINTS.TIMETABLE_DETAIL, {
+        params: { identifier: request.identifier },
+      })
+      .then((response) => {
+        console.log('시간표 상세 조회 성공', response.data);
+        return response.data as TimetableDetailResponse;
+      })
+      .catch((error) => {
+        console.error('시간표 상세 조회 에러:', error);
+        console.error('에러 상세:', {
+          message: error.message,
           status: error.response?.status,
           data: error.response?.data,
         });

--- a/src/apis/services/everytime.ts
+++ b/src/apis/services/everytime.ts
@@ -5,6 +5,8 @@ import type {
   TimetableListResponse,
   TimetableDetailRequest,
   TimetableDetailResponse,
+  TimetableImageRequest,
+  TimetableImageResponse,
 } from '@/apis/types/timetable';
 
 export const everytimeAPI = {
@@ -65,6 +67,41 @@ export const everytimeAPI = {
           status: error.response?.status,
           data: error.response?.data,
         });
+        throw error;
+      });
+  },
+  getTimetableDetailByImage: (request: TimetableImageRequest) => {
+    const formData = new FormData();
+    formData.append('image', request.image);
+
+    return apiClient
+      .post(EVERYTIME_ENDPOINTS.TIMETABLE_IMAGE, formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      })
+      .then((response) => {
+        console.log('시간표 이미지 파싱 성공', response.data);
+        return response.data as TimetableImageResponse;
+      })
+      .catch((error) => {
+        console.error('시간표 이미지 파싱 에러:', error);
+        console.error('에러 상세:', {
+          message: error.message,
+          status: error.response?.status,
+          data: error.response?.data,
+        });
+
+        // 403 에러인 경우 빈 시간표로 처리
+        if (error.response?.status === 403) {
+          console.log('이미지 파싱 권한이 없습니다. 빈 시간표로 처리합니다.');
+          return {
+            year: '',
+            semester: '',
+            subjects: [],
+          };
+        }
+
         throw error;
       });
   },

--- a/src/apis/types/timetable.ts
+++ b/src/apis/types/timetable.ts
@@ -1,0 +1,10 @@
+//시간표 목록 조회
+export interface TimetableListRequest {
+  url: string;
+}
+export interface TimetableResponse {
+  year: string;
+  semester: string;
+  identifier: string;
+}
+export type TimetableListResponse = TimetableResponse[];

--- a/src/apis/types/timetable.ts
+++ b/src/apis/types/timetable.ts
@@ -1,4 +1,4 @@
-//시간표 목록 조회
+//url을 통한 시간표 목록 조회
 export interface TimetableListRequest {
   url: string;
 }
@@ -9,7 +9,7 @@ export interface TimetableResponse {
 }
 export type TimetableListResponse = TimetableResponse[];
 
-//시간표 상세 조회
+//url을 통한 시간표 목록의 시간표 상세 조회
 export interface TimetableDetailRequest {
   identifier: string;
 }
@@ -18,6 +18,18 @@ export interface TimetableDetailResponse {
   semester: string;
   subjects: Subject[];
 }
+
+//이미지를 통한 시간표 상세 조회
+export interface TimetableImageRequest {
+  image: File;
+}
+export interface TimetableImageResponse {
+  year: string;
+  semester: string;
+  subjects: Subject[];
+}
+
+//시간표 response 결과
 export interface Subject {
   name: string;
   professor: string;

--- a/src/apis/types/timetable.ts
+++ b/src/apis/types/timetable.ts
@@ -8,3 +8,25 @@ export interface TimetableResponse {
   identifier: string;
 }
 export type TimetableListResponse = TimetableResponse[];
+
+//시간표 상세 조회
+export interface TimetableDetailRequest {
+  identifier: string;
+}
+export interface TimetableDetailResponse {
+  year: string;
+  semester: string;
+  subjects: Subject[];
+}
+export interface Subject {
+  name: string;
+  professor: string;
+  credit: number;
+  times: SubjectTime[];
+}
+export interface SubjectTime {
+  dayOfWeek: number;
+  startTime: string;
+  endTime: string;
+  place: string;
+}

--- a/src/components/atoms/ModalHeader.tsx
+++ b/src/components/atoms/ModalHeader.tsx
@@ -1,14 +1,15 @@
 const ModalHeader = ({ title }: { title: string }) => {
   return (
-    <div className="p-6">
-      <h2 className="flex justify-center text-xl font-semibold text-gray-900">{title}</h2>
+    <div className="p-2">
+      <h2 className="flex justify-center text-xl font-bold text-gray-900">{title}</h2>
 
-      {/* 진행 단계 표시 */}
+      {/* 진행 단계 표시
       <div className="flex justify-center mt-4 space-x-2">
         {Array.from({ length: 6 }).map((_, index) => (
           <div key={index} className={`w-4 h-4 bg-black rounded-full`} />
         ))}
       </div>
+      */}
     </div>
   );
 };

--- a/src/hooks/timetable/useImageParsing.ts
+++ b/src/hooks/timetable/useImageParsing.ts
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { everytimeAPI } from '@/apis';
+import type { TimetableImageResponse } from '@/apis';
+
+export const useImageParsing = () => {
+  // 이미지 파싱 상태
+  const [imageParsing, setImageParsing] = useState<boolean>(false);
+  const [parsedTimetable, setParsedTimetable] = useState<TimetableImageResponse | null>(null);
+  const [imageParseError, setImageParseError] = useState<string>('');
+
+  // 이미지 파싱 함수
+  const parseImageTimetable = (file: File) => {
+    setImageParsing(true);
+    setParsedTimetable(null);
+    setImageParseError('');
+
+    return everytimeAPI
+      .getTimetableDetailByImage({ image: file })
+      .then((result) => {
+        setParsedTimetable(result);
+      })
+      .catch((error) => {
+        if (error.response?.status !== 403) {
+          setImageParseError(`이미지 분석 실패`);
+        }
+      })
+      .finally(() => {
+        setImageParsing(false);
+      });
+  };
+
+  // 파싱 결과 초기화
+  const clearParsedData = () => {
+    setParsedTimetable(null);
+    setImageParseError('');
+  };
+
+  return {
+    imageParsing,
+    parsedTimetable,
+    imageParseError,
+
+    parseImageTimetable,
+    clearParsedData,
+  };
+};

--- a/src/hooks/timetable/useImageUpload.ts
+++ b/src/hooks/timetable/useImageUpload.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect } from 'react';
+
+export const useImageUpload = () => {
+  const [selectedImage, setSelectedImage] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+
+  // 언마운트 시 이미지 URL 정리
+  useEffect(() => {
+    return () => {
+      if (imagePreview) {
+        URL.revokeObjectURL(imagePreview);
+      }
+    };
+  }, [imagePreview]);
+
+  // 이미지 선택 핸들러
+  const handleImageSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (file) {
+      setSelectedImage(file);
+      const previewUrl = URL.createObjectURL(file);
+      setImagePreview(previewUrl);
+    } else {
+      console.log('파일이 없음');
+    }
+  };
+
+  // 이미지 초기화
+  const clearImage = () => {
+    if (imagePreview) {
+      URL.revokeObjectURL(imagePreview);
+    }
+    setSelectedImage(null);
+    setImagePreview(null);
+  };
+
+  return {
+    selectedImage,
+    imagePreview,
+
+    handleImageSelect,
+    clearImage,
+    setSelectedImage,
+  };
+};

--- a/src/hooks/timetable/useTimetableData.ts
+++ b/src/hooks/timetable/useTimetableData.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect } from 'react';
+import { everytimeAPI } from '@/apis';
+import type { TimetableResponse, TimetableDetailResponse } from '@/apis';
+
+export const useTimetableData = () => {
+  // 시간표 목록 관련 상태
+  const [timetableList, setTimetableList] = useState<TimetableResponse[]>([]);
+  const [selectedTimetable, setSelectedTimetable] = useState<TimetableResponse | null>(null);
+  const [timetableError, setTimetableError] = useState<string>('');
+
+  // 시간표 상세 정보 관련 상태
+  const [timetableDetail, setTimetableDetail] = useState<TimetableDetailResponse | null>(null);
+  const [detailError, setDetailError] = useState<string>('');
+
+  // 시간표 목록 조회
+  const getTimetables = (url: string) => {
+    if (!url.includes('everytime.kr')) {
+      setTimetableError('올바른 url을 입력해주세요.');
+      return;
+    }
+    setTimetableError('');
+    setTimetableList([]);
+    setSelectedTimetable(null);
+
+    everytimeAPI
+      .getTimetables({ url })
+      .then((timetables) => {
+        setTimetableList(timetables);
+        if (timetables.length > 0) {
+          setSelectedTimetable(timetables[0]);
+        }
+      })
+      .catch((error) => {
+        console.error('시간표 목록 조회 실패:', error);
+        setTimetableError('시간표 목록을 불러오는데 실패했습니다.');
+      });
+  };
+
+  // 시간표 상세 조회
+  const getTimetableDetail = (identifier: string) => {
+    setTimetableDetail(null);
+    setDetailError('');
+
+    everytimeAPI
+      .getTimetableDetail({ identifier })
+      .then((detail) => {
+        setTimetableDetail(detail);
+      })
+      .catch((error) => {
+        console.error('시간표 상세 조회 실패:', error);
+        setDetailError('시간표 상세 정보를 불러오는데 실패했습니다.');
+      });
+  };
+
+  // 시간표가 변경될 때 상세 정보 조회
+  useEffect(() => {
+    if (selectedTimetable?.identifier) {
+      getTimetableDetail(selectedTimetable.identifier);
+    }
+  }, [selectedTimetable]);
+
+  return {
+    timetableList,
+    selectedTimetable,
+    timetableError,
+    timetableDetail,
+    detailError,
+
+    getTimetables,
+    setSelectedTimetable,
+  };
+};

--- a/src/pages/Calendar/components/TimetableModal.tsx
+++ b/src/pages/Calendar/components/TimetableModal.tsx
@@ -33,6 +33,27 @@ const TimeTableModal: React.FC<TimeTableModalProps> = ({ isOpen, onClose }) => {
   const [parsedTimetable, setParsedTimetable] = useState<TimetableImageResponse | null>(null);
   const [imageParseError, setImageParseError] = useState<string>('');
 
+  //데이터 검증 함수
+  const validateTimetableData = (subjects: any[]) => {
+    if (!subjects || subjects.length === 0) {
+      return { isValid: false, message: '등록된 수업이 없습니다' };
+    }
+
+    for (const subject of subjects) {
+      if (!subject.times || subject.times.length === 0) {
+        continue;
+      }
+
+      for (const time of subject.times) {
+        if (!time.startTime || !time.endTime) {
+          return { isValid: false, message: '인식된 시간표가 없습니다' };
+        }
+      }
+    }
+
+    return { isValid: true, message: '' };
+  };
+
   //요일 변환 함수
   const getDayOfWeek = (dayOfWeek: number) => {
     const days = ['일', '월', '화', '수', '목', '금', '토'];
@@ -142,7 +163,7 @@ const TimeTableModal: React.FC<TimeTableModalProps> = ({ isOpen, onClose }) => {
       })
       .catch((error) => {
         if (error.response?.status !== 403) {
-          setImageParseError(`이미지 분석 실패: ${error.message}`);
+          setImageParseError(`이미지 분석 실패`);
         }
       })
       .finally(() => {
@@ -219,10 +240,14 @@ const TimeTableModal: React.FC<TimeTableModalProps> = ({ isOpen, onClose }) => {
                   ` (${parsedTimetable.year} ${parsedTimetable.semester})`}
               </label>
               <div className="max-h-60 overflow-y-auto border border-gray-200 rounded-md p-3 bg-gray-50">
-                {parsedTimetable.subjects.length === 0 ? (
-                  <div className="text-center text-gray-500 py-4">등록된 수업이 없습니다</div>
-                ) : (
-                  parsedTimetable.subjects.map((subject, index) => (
+                {(() => {
+                  const validation = validateTimetableData(parsedTimetable.subjects);
+                  if (!validation.isValid) {
+                    return (
+                      <div className="text-center text-red-500 py-4">{validation.message}</div>
+                    );
+                  }
+                  return parsedTimetable.subjects.map((subject, index) => (
                     <div key={index} className="mb-3 last:mb-0">
                       <div className="font-semibold text-gray-800 mb-1">{subject.name}</div>
                       {subject.times.map((time, timeIndex) => (
@@ -232,8 +257,8 @@ const TimeTableModal: React.FC<TimeTableModalProps> = ({ isOpen, onClose }) => {
                         </div>
                       ))}
                     </div>
-                  ))
-                )}
+                  ));
+                })()}
               </div>
             </div>
           )}
@@ -286,10 +311,12 @@ const TimeTableModal: React.FC<TimeTableModalProps> = ({ isOpen, onClose }) => {
                 ` (${timetableDetail.year}년 ${timetableDetail.semester}학기)`}
             </label>
             <div className="max-h-60 overflow-y-auto border border-gray-200 rounded-md p-3 bg-gray-50">
-              {timetableDetail.subjects.length === 0 ? (
-                <div className="text-center text-sm text-gray-500 py-4">등록된 수업이 없습니다</div>
-              ) : (
-                timetableDetail.subjects.map((subject, index) => (
+              {(() => {
+                const validation = validateTimetableData(timetableDetail.subjects);
+                if (!validation.isValid) {
+                  return <div className="text-center text-red-500 py-4">{validation.message}</div>;
+                }
+                return timetableDetail.subjects.map((subject, index) => (
                   <div key={index} className="mb-3 last:mb-0">
                     <div className="font-semibold text-gray-800 mb-1">{subject.name}</div>
                     {subject.times.map((time, timeIndex) => (
@@ -299,8 +326,8 @@ const TimeTableModal: React.FC<TimeTableModalProps> = ({ isOpen, onClose }) => {
                       </div>
                     ))}
                   </div>
-                ))
-              )}
+                ));
+              })()}
             </div>
           </div>
         )}

--- a/src/pages/Calendar/components/TimetableModal.tsx
+++ b/src/pages/Calendar/components/TimetableModal.tsx
@@ -1,9 +1,11 @@
+import React, { useEffect, useState } from 'react';
 import Button from '@/components/atoms/Button';
 import Modal from '@/components/molecules/Modal';
 import ModalHeader from '@/components/atoms/ModalHeader';
 import { FormInput } from '@/components/atoms/FormInput';
 import ImageInput from '@/pages/Calendar/components/ImageInput';
-import React, { useEffect, useState } from 'react';
+import { everytimeAPI } from '@/apis';
+import type { TimetableResponse } from '@/apis';
 
 interface TimeTableModalProps {
   isOpen: boolean;
@@ -16,6 +18,12 @@ const TimeTableModal: React.FC<TimeTableModalProps> = ({ isOpen, onClose }) => {
   const [startDate, setStartDate] = useState<Date>(new Date('2025-03-01'));
   const [endDate, setEndDate] = useState<Date>(new Date('2025-12-21'));
   const [everytimeTable, setEverytimeTable] = useState<string>('');
+
+  //시간표 목록
+  const [timetableList, setTimetableList] = useState<TimetableResponse[]>([]);
+  const [selectedTimetable, setSelectedTimetable] = useState<TimetableResponse | null>(null);
+  const [timetableError, setTimetableError] = useState<string>('');
+
   // 언마운트 시 이미지 URL 정리
   useEffect(() => {
     return () => {
@@ -24,6 +32,44 @@ const TimeTableModal: React.FC<TimeTableModalProps> = ({ isOpen, onClose }) => {
       }
     };
   }, [imagePreview]);
+
+  //시간표 목록 조회
+  const getTimetables = (url: string) => {
+    if (!url.includes('everytime.kr')) {
+      setTimetableError('올바른 url을 입력해주세요.');
+      return;
+    }
+    setTimetableError('');
+    setTimetableList([]);
+    setSelectedTimetable(null);
+
+    everytimeAPI
+      .getTimetables({ url })
+      .then((timetables) => {
+        setTimetableList(timetables);
+        if (timetables.length > 0) {
+          setSelectedTimetable(timetables[0]);
+        }
+      })
+      .catch((error) => {
+        console.error('시간표 목록 조회 실패:', error);
+        setTimetableError('시간표 목록을 불러오는데 실패했습니다.');
+      });
+  };
+
+  //url 입력 -> 자동 조회
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      if (everytimeTable && everytimeTable.includes('everytime.kr')) {
+        getTimetables(everytimeTable);
+      } else {
+        setTimetableList([]);
+        setSelectedTimetable(null);
+        setTimetableError('');
+      }
+    }, 500);
+    return () => clearTimeout(timeoutId);
+  }, [everytimeTable]);
 
   const handleImageSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -35,7 +81,18 @@ const TimeTableModal: React.FC<TimeTableModalProps> = ({ isOpen, onClose }) => {
   };
 
   const handleSubmit = () => {
-    console.log('시간표 등록:', { selectedImage, startDate, endDate });
+    if (selectedTimetable) {
+      console.log('선택된 시간표:', selectedTimetable);
+      console.log('시간표 등록:', {
+        selectedImage,
+        startDate,
+        endDate,
+        timetableInfo: selectedTimetable,
+        everytimeUrl: everytimeTable,
+      });
+    } else {
+      console.log('시간표 등록:', { selectedImage, startDate, endDate });
+    }
     onClose();
   };
 
@@ -43,9 +100,9 @@ const TimeTableModal: React.FC<TimeTableModalProps> = ({ isOpen, onClose }) => {
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalHeader title="시간표 추가하기" />
 
-      <div className="p-6 m-4 rounded-lg border border-gray-200">
+      <div className="p-6 m-3 rounded-lg border border-gray-200">
         {/* 이미지 업로드 섹션 */}
-        <div className="mb-8">
+        <div className="mb-3">
           <label className="block mb-3 text-lg font-bold text-gray-700">
             에브리타임 시간표 업로드
           </label>
@@ -63,10 +120,39 @@ const TimeTableModal: React.FC<TimeTableModalProps> = ({ isOpen, onClose }) => {
             type="text"
             className="mt-4"
           />
+          <div className="m-2 text-xs text-center text-gray-400">
+            링크로 시간표를 등록하시는 경우, <br />
+            공개 범위를 전체 공개로 변경해주세요.
+          </div>
         </div>
 
+        {/* 시간표 학기 선택 */}
+        {timetableList.length > 0 && (
+          <div className="mb-4">
+            <label className="block mb-2 text-sm font-bold text-gray-700">시간표 선택</label>
+            <select
+              value={selectedTimetable?.identifier || ''}
+              onChange={(e) => {
+                const selected = timetableList.find((t) => t.identifier === e.target.value);
+                setSelectedTimetable(selected || null);
+              }}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-transparent"
+            >
+              <option value="">시간표를 선택하세요</option>
+              {timetableList.map((timetable) => (
+                <option key={timetable.identifier} value={timetable.identifier}>
+                  {timetable.year}년 {timetable.semester}학기
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+        {timetableError && (
+          <div className="m-3 text-sm text-center text-red-600">{timetableError}</div>
+        )}
+
         {/* 날짜 입력 필드 */}
-        <div className="space-y-4">
+        <div className="space-y-3">
           <div className="flex flex-row space-x-2">
             <label className="flex justify-between items-center mb-2 text-sm font-bold text-gray-700 text-nowrap">
               학기 시작일 :
@@ -92,7 +178,7 @@ const TimeTableModal: React.FC<TimeTableModalProps> = ({ isOpen, onClose }) => {
           </div>
         </div>
       </div>
-      <Button handleSubmit={handleSubmit} text="등록하기" className="flex justify-center w-full" />
+      <Button onClick={handleSubmit} text="등록하기" className="flex justify-center w-full" />
     </Modal>
   );
 };

--- a/src/pages/Calendar/components/TimetableModal.tsx
+++ b/src/pages/Calendar/components/TimetableModal.tsx
@@ -178,7 +178,6 @@ const TimeTableModal: React.FC<TimeTableModalProps> = ({ isOpen, onClose }) => {
               }}
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-transparent"
             >
-              <option value="">시간표를 선택하세요</option>
               {timetableList.map((timetable) => (
                 <option key={timetable.identifier} value={timetable.identifier}>
                   {timetable.year}년 {timetable.semester}학기
@@ -192,25 +191,30 @@ const TimeTableModal: React.FC<TimeTableModalProps> = ({ isOpen, onClose }) => {
         )}
 
         {/* 시간표 상세 정보 */}
-        {detailError && <div className="mb-4 p-4 text-center text-red-600">{detailError}</div>}
-
         {timetableDetail && (
           <div className="mb-4">
             <label className="block mb-2 text-sm font-bold text-gray-700">
-              시간표 정보 ({timetableDetail.year}년 {timetableDetail.semester}학기)
+              시간표 정보
+              {timetableDetail.year &&
+                timetableDetail.semester &&
+                ` (${timetableDetail.year}년 ${timetableDetail.semester}학기)`}
             </label>
             <div className="max-h-60 overflow-y-auto border border-gray-200 rounded-md p-3 bg-gray-50">
-              {timetableDetail.subjects.map((subject, index) => (
-                <div key={index} className="mb-3 last:mb-0">
-                  <div className="font-semibold text-gray-800 mb-1">{subject.name}</div>
-                  {subject.times.map((time, timeIndex) => (
-                    <div key={timeIndex} className="ml-2 text-sm text-gray-600">
-                      {getDayOfWeek(time.dayOfWeek)} {formatTime(time.startTime)} -{' '}
-                      {formatTime(time.endTime)}
-                    </div>
-                  ))}
-                </div>
-              ))}
+              {timetableDetail.subjects.length === 0 ? (
+                <div className="text-center text-sm text-gray-500 py-4">등록된 수업이 없습니다</div>
+              ) : (
+                timetableDetail.subjects.map((subject, index) => (
+                  <div key={index} className="mb-3 last:mb-0">
+                    <div className="font-semibold text-gray-800 mb-1">{subject.name}</div>
+                    {subject.times.map((time, timeIndex) => (
+                      <div key={timeIndex} className="ml-2 text-sm text-gray-600">
+                        {getDayOfWeek(time.dayOfWeek)} {formatTime(time.startTime)} -{' '}
+                        {formatTime(time.endTime)}
+                      </div>
+                    ))}
+                  </div>
+                ))
+              )}
             </div>
           </div>
         )}

--- a/src/utils/timetableUtils.ts
+++ b/src/utils/timetableUtils.ts
@@ -1,0 +1,43 @@
+/**
+ * 시간표 데이터 검증 함수
+ * @param subjects 시간표 과목 배열
+ * @returns 검증 결과 객체
+ */
+export const validateTimetableData = (subjects: any[]) => {
+  if (!subjects || subjects.length === 0) {
+    return { isValid: false, message: '등록된 수업이 없습니다' };
+  }
+
+  for (const subject of subjects) {
+    if (!subject.times || subject.times.length === 0) {
+      continue;
+    }
+
+    for (const time of subject.times) {
+      if (!time.startTime || !time.endTime) {
+        return { isValid: false, message: '인식된 시간표가 없습니다' };
+      }
+    }
+  }
+
+  return { isValid: true, message: '' };
+};
+
+/**
+ * 요일 숫자를 한글 요일로 변환
+ * @param dayOfWeek 요일 숫자 (0: 일요일, 1: 월요일, ...)
+ * @returns 한글 요일 문자열
+ */
+export const getDayOfWeek = (dayOfWeek: number) => {
+  const days = ['일', '월', '화', '수', '목', '금', '토'];
+  return days[dayOfWeek];
+};
+
+/**
+ * 시간 문자열을 HH:MM 형식으로 포맷팅
+ * @param time 시간 문자열 (HH:MM:SS 또는 HH:MM)
+ * @returns HH:MM 형식의 시간 문자열
+ */
+export const formatTime = (time: string) => {
+  return time.substring(0, 5);
+};


### PR DESCRIPTION
# 📝 PR 설명

## 변경 사항

- 에브리타임 시간표 이미지 파싱 및 url 등록 api를 연동합니다.

## 상세 설명

- 에브리타임 시간표 이미지 등록 api 연동
- 에브리타임 url 시간표 목록 요청 api 연동
- 에브리타임 시간표 상세 요청 api 연동
- 현재 시간표 파싱 결과를 사용자가 확인할 수 있습니다. 다만, 아직 수정 기능은 만들지 않았습니다.

## 리뷰 해야할 부분

- [ ] 3가지 기능이 원활히 동작하는지
- [ ] `timetableModal.tsx` 파일에서 컴포넌트로 더 분리할 수 있는 부분이 있는지
- [ ] `hooks/timetable/` 아래의 훅 분리는 적절한지
- [ ] `utils/` 아래의 유틸 분리는 적절한지

## 스크린샷 (UI 변경이 있는 경우)

<img width="417" height="628" alt="스크린샷 2025-09-26 오후 1 13 04" src="https://github.com/user-attachments/assets/4e814379-73db-4726-9d21-38980153581f" />

<img width="433" height="864" alt="스크린샷 2025-09-26 오후 1 13 21" src="https://github.com/user-attachments/assets/b85518a4-7f66-4e55-adb8-315e2fdd08d8" />

<img width="438" height="652" alt="스크린샷 2025-09-26 오후 1 13 39" src="https://github.com/user-attachments/assets/0f5698fb-ba8c-44b4-902a-bb0cf0781e98" />

<img width="421" height="676" alt="스크린샷 2025-09-26 오후 1 14 26" src="https://github.com/user-attachments/assets/ebc7d98d-e22e-406c-9861-06f5b62bc543" />

<img width="358" height="483" alt="스크린샷 2025-09-26 오후 1 14 47" src="https://github.com/user-attachments/assets/223db1e3-51c2-47b2-8b30-450b51a05167" />
