### PR TITLE
Feat: 캘린더 분리 및 팀 일정 crud api 연동

### DIFF
--- a/src/apis/constants/endpoints.ts
+++ b/src/apis/constants/endpoints.ts
@@ -10,7 +10,7 @@ export const CALENDAR_ENDPOINTS = {
   GET_EVENTS: '/api/events',
   ADD_EVENT: '/api/events/add',
   MODIFY_EVENT: '/api/events/modify',
-  DELETE_EVENT: (eventId: number) => `/calendar/events/${eventId}`,
+  DELETE_EVENT: (eventId: number) => `/api/events/${eventId}`,
 } as const;
 
 export const EVERYTIME_ENDPOINTS = {

--- a/src/apis/constants/endpoints.ts
+++ b/src/apis/constants/endpoints.ts
@@ -6,11 +6,18 @@ export const AUTH_ENDPOINTS = {
   REFRESH: '/api/members/refresh',
 } as const;
 
-export const CALENDAR_ENDPOINTS = {
+export const PERSONAL_CALENDAR_ENDPOINTS = {
   GET_EVENTS: '/api/events',
   ADD_EVENT: '/api/events/add',
   MODIFY_EVENT: '/api/events/modify',
   DELETE_EVENT: (eventId: number) => `/api/events/${eventId}`,
+} as const;
+
+export const TEAM_CALENDAR_ENDPOINTS = {
+  GET_EVENTS: (teamId: number) => `/api/events/team/${teamId}`,
+  ADD_EVENT: '/api/events/team/add',
+  MODIFY_EVENT: '/api/events/team/modify',
+  DELETE_EVENT: (eventId: number) => `/api/events/team/${eventId}`,
 } as const;
 
 export const EVERYTIME_ENDPOINTS = {

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -2,12 +2,13 @@ export { apiClient } from '@/apis/client/apiClients';
 export {
   API_BASE_URL,
   AUTH_ENDPOINTS,
-  CALENDAR_ENDPOINTS,
+  PERSONAL_CALENDAR_ENDPOINTS,
+  TEAM_CALENDAR_ENDPOINTS,
   EVERYTIME_ENDPOINTS,
   TEAM_ENDPOINTS,
 } from '@/apis/constants/endpoints';
 export { authAPI } from '@/apis/services/auth';
-export { calendarAPI } from '@/apis/services/calendar';
+export { personalCalendarAPI, teamCalendarAPI } from '@/apis/services/calendar';
 export { everytimeAPI } from '@/apis/services/everytime';
 export { teamAPI } from '@/apis/services/team';
 export type * from '@/apis/types/auth';

--- a/src/apis/services/calendar.ts
+++ b/src/apis/services/calendar.ts
@@ -1,24 +1,34 @@
-import { CALENDAR_ENDPOINTS, apiClient } from '@/apis';
+import { PERSONAL_CALENDAR_ENDPOINTS, TEAM_CALENDAR_ENDPOINTS, apiClient } from '@/apis';
 import type {
   addCalendarEventRequest,
   addCalendarEventResponse,
   modifyCalendarEventRequest,
   modifyCalendarEventResponse,
 } from '@/types/calendar';
+import type { addTeamCalendarEventRequest, addTeamCalendarEventResponse } from '@/apis';
 
-export const calendarAPI = {
+export const personalCalendarAPI = {
   getEvents: (params: { startAt: string; endAt: string }) => {
-    return apiClient.get(CALENDAR_ENDPOINTS.GET_EVENTS, {
+    return apiClient.get(PERSONAL_CALENDAR_ENDPOINTS.GET_EVENTS, {
       params,
     });
   },
   addEvent: (event: addCalendarEventRequest): Promise<addCalendarEventResponse> => {
-    return apiClient.post(CALENDAR_ENDPOINTS.ADD_EVENT, event);
+    return apiClient.post(PERSONAL_CALENDAR_ENDPOINTS.ADD_EVENT, event);
   },
   modifyEvent: (event: modifyCalendarEventRequest): Promise<modifyCalendarEventResponse> => {
-    return apiClient.patch(CALENDAR_ENDPOINTS.MODIFY_EVENT, event);
+    return apiClient.patch(PERSONAL_CALENDAR_ENDPOINTS.MODIFY_EVENT, event);
   },
   deleteEvent: (eventId: number) => {
-    return apiClient.delete(CALENDAR_ENDPOINTS.DELETE_EVENT(eventId));
+    return apiClient.delete(PERSONAL_CALENDAR_ENDPOINTS.DELETE_EVENT(eventId));
+  },
+};
+
+export const teamCalendarAPI = {
+  getTeamEvents(teamId: number, params: { startAt: string; endAt: string }) {
+    return apiClient.get(TEAM_CALENDAR_ENDPOINTS.GET_EVENTS(teamId), { params });
+  },
+  addTeamEvent: (teamEvent: addTeamCalendarEventRequest): Promise<addTeamCalendarEventResponse> => {
+    return apiClient.post(TEAM_CALENDAR_ENDPOINTS.ADD_EVENT, teamEvent);
   },
 };

--- a/src/apis/services/calendar.ts
+++ b/src/apis/services/calendar.ts
@@ -31,4 +31,12 @@ export const teamCalendarAPI = {
   addTeamEvent: (teamEvent: addTeamCalendarEventRequest): Promise<addTeamCalendarEventResponse> => {
     return apiClient.post(TEAM_CALENDAR_ENDPOINTS.ADD_EVENT, teamEvent);
   },
+  modifyTeamEvent: (
+    teamEvent: modifyCalendarEventRequest,
+  ): Promise<modifyCalendarEventResponse> => {
+    return apiClient.patch(TEAM_CALENDAR_ENDPOINTS.MODIFY_EVENT, teamEvent);
+  },
+  deleteTeamEvent: (eventId: number) => {
+    return apiClient.delete(TEAM_CALENDAR_ENDPOINTS.DELETE_EVENT(eventId));
+  },
 };

--- a/src/apis/types/calendar.ts
+++ b/src/apis/types/calendar.ts
@@ -2,3 +2,49 @@ import { type CalendarEvent } from '@/types/calendar';
 
 // API가 배열을 직접 반환하므로 타입을 배열로 변경
 export type getCalendarEventsResponse = CalendarEvent[];
+
+//팀 일정 조회
+export type getTeamCalendarEventsResponse = {
+  event_id: number;
+  title: string;
+  description?: string;
+  start_time: string;
+  end_time?: string;
+  is_private: boolean;
+}[];
+
+//팀 일정 추가
+export interface addTeamCalendarEventRequest {
+  team_id: number;
+  title: string;
+  description?: string;
+  start_time: string;
+  end_time?: string;
+  is_private: boolean;
+}
+export interface addTeamCalendarEventResponse {
+  event_id: number;
+  title: string;
+  description?: string;
+  start_time: string;
+  end_time?: string;
+  is_private: boolean;
+}
+
+//팀 일정 수정
+export interface modifyTeamCalendarEventRequest {
+  team_id: number;
+  title?: string;
+  description?: string;
+  start_time?: string;
+  end_time?: string;
+  is_private?: boolean;
+}
+export interface modifyTeamCalendarEventResponse {
+  event_id: number;
+  title?: string;
+  description?: string;
+  start_time?: string;
+  end_time?: string;
+  is_private?: boolean;
+}

--- a/src/apis/types/calendar.ts
+++ b/src/apis/types/calendar.ts
@@ -1,4 +1,4 @@
-import { type CalendarEvent } from '@/types/calendar';
+import type { CalendarEvent } from '@/types/calendar';
 
 // API가 배열을 직접 반환하므로 타입을 배열로 변경
 export type getCalendarEventsResponse = CalendarEvent[];
@@ -33,7 +33,7 @@ export interface addTeamCalendarEventResponse {
 
 //팀 일정 수정
 export interface modifyTeamCalendarEventRequest {
-  team_id: number;
+  event_id: number;
   title?: string;
   description?: string;
   start_time?: string;
@@ -42,9 +42,9 @@ export interface modifyTeamCalendarEventRequest {
 }
 export interface modifyTeamCalendarEventResponse {
   event_id: number;
-  title?: string;
+  title: string;
   description?: string;
-  start_time?: string;
-  end_time?: string;
-  is_private?: boolean;
+  start_time: string;
+  end_time: string;
+  is_private: boolean;
 }

--- a/src/hooks/calendar/useEventForm.ts
+++ b/src/hooks/calendar/useEventForm.ts
@@ -31,7 +31,7 @@ const useEventForm = ({ onSave, onClose }: UseEventFormProps) => {
 
     const eventData: Omit<CalendarEvent, 'event_id'> = {
       title: formData.title,
-      description: '',
+      description: formData.description || '',
       start_time: startTime,
       end_time: endTime,
       is_private: formData.private,

--- a/src/hooks/calendar/useFormData.ts
+++ b/src/hooks/calendar/useFormData.ts
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react';
 
 export interface FormData {
   title: string;
+  description: string;
   private: boolean;
   allDay: boolean;
   repeat: RepeatType;
@@ -30,6 +31,7 @@ const useFormData = ({ isOpen, modalType, selectedEvent, selectedDate }: UseForm
   const [showTime, setShowTime] = useState(false);
   const [formData, setFormData] = useState<FormData>({
     title: '',
+    description: '',
     startTime: '',
     endTime: '',
     private: false,
@@ -47,6 +49,7 @@ const useFormData = ({ isOpen, modalType, selectedEvent, selectedDate }: UseForm
       if (modalType === 'edit' && selectedEvent) {
         setFormData({
           title: selectedEvent.title,
+          description: selectedEvent.description,
           startTime: toDateOnly(selectedEvent.start_time),
           endTime: toDateOnly(selectedEvent.end_time),
           private: selectedEvent.is_private ?? false,
@@ -62,6 +65,7 @@ const useFormData = ({ isOpen, modalType, selectedEvent, selectedDate }: UseForm
       } else if (modalType === 'add' && selectedDate) {
         setFormData({
           title: '',
+          description: '',
           startTime: selectedDate,
           endTime: selectedDate,
           private: false,
@@ -75,6 +79,7 @@ const useFormData = ({ isOpen, modalType, selectedEvent, selectedDate }: UseForm
       } else {
         setFormData({
           title: '',
+          description: '',
           startTime: toDateOnly(new Date()),
           endTime: toDateOnly(new Date()),
           private: false,

--- a/src/hooks/calendar/useFormData.ts
+++ b/src/hooks/calendar/useFormData.ts
@@ -50,8 +50,8 @@ const useFormData = ({ isOpen, modalType, selectedEvent, selectedDate }: UseForm
         setFormData({
           title: selectedEvent.title,
           description: selectedEvent.description,
-          startTime: toDateOnly(selectedEvent.start_time),
-          endTime: toDateOnly(selectedEvent.end_time),
+          startTime: selectedEvent.start_time,
+          endTime: selectedEvent.end_time,
           private: selectedEvent.is_private ?? false,
           allDay: false,
           repeat: 'none',
@@ -92,7 +92,7 @@ const useFormData = ({ isOpen, modalType, selectedEvent, selectedDate }: UseForm
         });
       }
     }
-  }, [isOpen, modalType, selectedEvent, selectedDate]);
+  }, [isOpen, modalType, selectedEvent?.event_id, selectedDate]);
 
   const updateFormData = (updates: Partial<FormData>) => {
     setFormData((prev) => ({ ...prev, ...updates }));

--- a/src/pages/Calendar/FullCalendar.tsx
+++ b/src/pages/Calendar/FullCalendar.tsx
@@ -151,12 +151,6 @@ const CalendarPage = ({ mode = 'personal' }: CalendarProps) => {
       if (eventData.description !== selectedEvent.description) {
         modifyData.description = eventData.description;
       }
-      if (eventData.start_time !== selectedEvent.start_time) {
-        modifyData.start_time = eventData.start_time;
-      }
-      if (eventData.end_time !== selectedEvent.end_time) {
-        modifyData.end_time = eventData.end_time;
-      }
       if (eventData.is_private !== selectedEvent.is_private) {
         modifyData.is_private = eventData.is_private;
       }

--- a/src/pages/Calendar/FullCalendar.tsx
+++ b/src/pages/Calendar/FullCalendar.tsx
@@ -163,15 +163,23 @@ const CalendarPage = ({ mode = 'personal' }: CalendarProps) => {
 
       console.log('modify payload:', modifyData);
 
-      personalCalendarAPI.modifyEvent(modifyData);
+      if (mode === 'team') {
+        await teamCalendarAPI.modifyTeamEvent(modifyData);
+      } else {
+        await personalCalendarAPI.modifyEvent(modifyData);
+      }
       updateEvent(selectedEvent.event_id, eventData);
     }
   };
 
   // 모달에서 이벤트 삭제 핸들러
-  const handleDeleteEvent = (eventId: number) => {
+  const handleDeleteEvent = async (eventId: number) => {
+    if (mode === 'team') {
+      await teamCalendarAPI.deleteTeamEvent(eventId);
+    } else {
+      await personalCalendarAPI.deleteEvent(eventId);
+    }
     removeEvent(eventId);
-    personalCalendarAPI.deleteEvent(eventId);
   };
 
   return (

--- a/src/pages/Calendar/FullCalendar.tsx
+++ b/src/pages/Calendar/FullCalendar.tsx
@@ -154,6 +154,14 @@ const CalendarPage = ({ mode = 'personal' }: CalendarProps) => {
       if (eventData.is_private !== selectedEvent.is_private) {
         modifyData.is_private = eventData.is_private;
       }
+      if (eventData.start_time !== selectedEvent.start_time) {
+        modifyData.start_time = eventData.start_time;
+        modifyData.end_time = eventData.end_time;
+      }
+      if (eventData.end_time !== selectedEvent.end_time) {
+        modifyData.start_time = eventData.start_time;
+        modifyData.end_time = eventData.end_time;
+      }
 
       console.log('modify payload:', modifyData);
 

--- a/src/pages/Calendar/components/DateModal.tsx
+++ b/src/pages/Calendar/components/DateModal.tsx
@@ -97,7 +97,7 @@ const DateModal: React.FC<DateModalProps> = ({
         <form onSubmit={handleFormSubmit} className="p-6">
           <div className="flex flex-col space-y-2 md:flex-row md:w-full">
             {/** 일정 제목, 비공개 여부, 시간 추가 (모달 우측) */}
-            <div className="mt-4 min-h-[400px]">
+            <div className="mt-4">
               <MetaFields formData={formData} range={range} updateFormData={updateFormData} />
               <RepeatSettings formData={formData} updateFormData={updateFormData} />
             </div>
@@ -128,7 +128,7 @@ const DateModal: React.FC<DateModalProps> = ({
               variant="primary"
               size="md"
               noWrapper={true}
-              className="flex justify-center items-center w-[20%] h-[40px] bg-blue-500 hover:bg-blue-600"
+              className="flex justify-center items-center w-[20%] h-[40px] mt-2 bg-blue-500 hover:bg-blue-600"
             />
           </div>
         </form>

--- a/src/pages/Calendar/components/DateModal.tsx
+++ b/src/pages/Calendar/components/DateModal.tsx
@@ -33,6 +33,17 @@ const DateModal: React.FC<DateModalProps> = ({
 }) => {
   const [range, setRange] = useState<DateRange | undefined>();
 
+  //일정 수정 시에 저장된 날짜 불러오기
+  useEffect(() => {
+    if (isOpen && modalType === 'edit' && selectedEvent) {
+      const startDate = new Date(selectedEvent.start_time);
+      const endDate = new Date(selectedEvent.end_time);
+      setRange({ from: startDate, to: endDate });
+    } else if (isOpen && modalType === 'add') {
+      setRange(undefined);
+    }
+  }, [isOpen, modalType, selectedEvent]);
+
   const { formData, updateFormData } = useFormData({
     isOpen,
     modalType,
@@ -51,7 +62,17 @@ const DateModal: React.FC<DateModalProps> = ({
       // 로컬 시간을 사용하여 날짜 형식 변환 (YYYY-MM-DD)
       const startDate = `${range.from.getFullYear()}-${String(range.from.getMonth() + 1).padStart(2, '0')}-${String(range.from.getDate()).padStart(2, '0')}`;
       const endDate = `${range.to.getFullYear()}-${String(range.to.getMonth() + 1).padStart(2, '0')}-${String(range.to.getDate()).padStart(2, '0')}`;
-      updateFormData({ startTime: startDate, endTime: endDate });
+
+      // 기존 시간 정보가 있으면 유지, 없으면 날짜만 설정
+      const existingStartTime = formData.startTime?.includes('T')
+        ? formData.startTime.split('T')[1]
+        : '';
+      const existingEndTime = formData.endTime?.includes('T') ? formData.endTime.split('T')[1] : '';
+
+      updateFormData({
+        startTime: existingStartTime ? `${startDate}T${existingStartTime}` : startDate,
+        endTime: existingEndTime ? `${endDate}T${existingEndTime}` : endDate,
+      });
     }
   }, [range?.from, range?.to]);
 

--- a/src/pages/Calendar/components/DateModal.tsx
+++ b/src/pages/Calendar/components/DateModal.tsx
@@ -145,11 +145,11 @@ const DateModal: React.FC<DateModalProps> = ({
             )}
             <Button
               type="submit"
-              text={modalType === 'add' ? '추가' : '수정'}
+              text={modalType === 'add' ? '추가' : '등록'}
               variant="primary"
               size="md"
               noWrapper={true}
-              className="flex justify-center items-center w-[20%] h-[40px] mt-2 bg-blue-500 hover:bg-blue-600"
+              className="flex justify-center items-center w-[20%] h-[40px] bg-blue-500 hover:bg-blue-600"
             />
           </div>
         </form>

--- a/src/pages/Calendar/components/MetaFields.tsx
+++ b/src/pages/Calendar/components/MetaFields.tsx
@@ -26,7 +26,17 @@ const MetaFields: React.FC<MetaFieldsProps> = ({ formData, range, updateFormData
         placeholder="일정 제목을 입력하세요"
         required
         error={error === 'title' ? '일정 제목을 입력해주세요' : undefined}
-        className="p-4"
+        className="m-4"
+      />
+      <FormInput
+        id="description"
+        label="메모"
+        value={formData.description}
+        onChange={(value) => {
+          updateFormData({ description: value });
+        }}
+        placeholder="메모를 입력하세요"
+        className="m-4"
       />
       <div className="flex gap-4 -mt-1">
         <FormInput

--- a/src/pages/Calendar/components/RepeatSettings.tsx
+++ b/src/pages/Calendar/components/RepeatSettings.tsx
@@ -19,7 +19,7 @@ const RepeatSettings: React.FC<RepeatSettingsProps> = ({ formData, updateFormDat
   ];
 
   return (
-    <div className="p-4 mt-2">
+    <div className="pt-4 px-4 mt-2">
       <div className="space-y-2">
         <FormInput
           id="repeat"

--- a/src/pages/Calendar/components/SelectDuration.tsx
+++ b/src/pages/Calendar/components/SelectDuration.tsx
@@ -1,6 +1,5 @@
 import { ko } from 'date-fns/locale';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { useEffect } from 'react';
 import type { DateRange, MonthCaptionProps } from 'react-day-picker';
 import { DayPicker, useDayPicker } from 'react-day-picker';
 import 'react-day-picker/dist/style.css';
@@ -46,10 +45,6 @@ function CustomCaption(props: MonthCaptionProps) {
 }
 
 const SelectDuration: React.FC<Props> = ({ range, setRange }) => {
-  useEffect(() => {
-    setRange(undefined);
-  }, []);
-
   return (
     <div className="date-picker">
       {/* 캘린더 컨테이너 */}

--- a/src/pages/Calendar/components/TimeFields.tsx
+++ b/src/pages/Calendar/components/TimeFields.tsx
@@ -18,10 +18,9 @@ const TimeFields: React.FC<TimeFieldsProps> = ({ formData, range, updateFormData
       <div
         className={`transition-all duration-300 ${!formData.allDay ? 'opacity-100 h-auto' : 'opacity-0 h-0 overflow-hidden'}`}
       >
-        <div className="flex flex-row gap-7 ml-4 -mt-4">
+        <div className="flex flex-row gap-6 ml-4 -mt-4">
           <FormInput
             id="startTime"
-            label="시작 시간"
             value={getTimePart(formData.startTime) || ''}
             onChange={(value) => {
               updateFormData({
@@ -34,7 +33,6 @@ const TimeFields: React.FC<TimeFieldsProps> = ({ formData, range, updateFormData
           />
           <FormInput
             id="endTime"
-            label="종료 시간"
             value={getTimePart(formData.endTime) || ''}
             onChange={(value) => {
               updateFormData({

--- a/src/pages/PersonalCalendar/index.tsx
+++ b/src/pages/PersonalCalendar/index.tsx
@@ -23,7 +23,7 @@ const PersonalCalendarPage = () => {
       {/* 메인 콘텐츠 영역 */}
       <div className="flex overflow-x-hidden flex-col flex-1 pb-4 bg-gradient-to-br from-blue-50 to-indigo-100 lg:flex-row xl:pl-0">
         <div className="flex-1 lg:flex-[3]">
-          <FullCalendar />
+          <FullCalendar mode="personal" />
         </div>
 
         <div className="flex flex-col m-2 gap-8 lg:flex-[1] lg:max-w-sm">

--- a/src/pages/TeamCalendar/index.tsx
+++ b/src/pages/TeamCalendar/index.tsx
@@ -22,7 +22,7 @@ const TeamCalendarPage = () => {
         {!showAvailability ? (
           <>
             <div className="flex-1 transition-all duration-500 ease-in-out">
-              <FullCalendar />
+              <FullCalendar mode="team" />
             </div>
 
             <div className="px-2 py-2 pr-4 w-[400px] transition-all duration-500 ease-in-out transform">
@@ -55,7 +55,7 @@ const TeamCalendarPage = () => {
               </div>
 
               <div className="flex-1 p-0">
-                <FullCalendar />
+                <FullCalendar mode="team" />
               </div>
             </div>
           ) : (

--- a/src/styles/fullCalendar.css
+++ b/src/styles/fullCalendar.css
@@ -85,7 +85,7 @@
 
   .fc-prev-button:hover,
   .fc-next-button:hover {
-    @apply shadow-md transform -translate-y-0.5 !bg-gray-200 !border-gray-200;
+    @apply shadow-md !bg-gray-200 !border-gray-200;
   }
   /* 새 일정 버튼 스타일 */
   .fc-addEvent-button {
@@ -165,7 +165,7 @@
   }
 
   .fc-event:hover {
-    @apply shadow-md transform scale-105 !z-10;
+    @apply shadow-md transform !z-10;
   }
 
   /* 일반 단일 날짜 이벤트 */
@@ -175,12 +175,12 @@
 
   /* 여러 날에 걸친 이벤트 - 시작 부분 */
   .fc-event.fc-daygrid-event.fc-event-start {
-    @apply !rounded-l-xl !rounded-r-sm !mr-0;
+    @apply !rounded-l-lg !rounded-r-sm !mr-0;
   }
 
   /* 여러 날에 걸친 이벤트 - 끝 부분 */
   .fc-event.fc-daygrid-event.fc-event-end {
-    @apply !rounded-r-xl !ml-0;
+    @apply !rounded-r-lg !ml-0;
   }
 
   /* 여러 날에 걸친 이벤트 - 중간 부분 */
@@ -195,12 +195,12 @@
 
   /* 이벤트 텍스트 스타일 */
   .fc-event-title {
-    @apply !font-medium !text-sm !overflow-visible !whitespace-nowrap;
+    @apply !font-medium !text-xs !overflow-visible !whitespace-nowrap;
   }
 
   /* 이벤트 시간 표시 */
   .fc-event-time {
-    @apply !text-xs !opacity-90 !mr-1;
+    @apply !text-xs !opacity-90 !mr-2 !ml-1;
   }
 
   /* 날짜 셀 스타일 */
@@ -238,16 +238,16 @@
 
   /* 날짜 셀 내부 요소들도 둥글게 */
   .fc-daygrid-day-events {
-    @apply !rounded-xl;
+    @apply !rounded-lg;
   }
 
   /* 날짜 셀 내부 모든 요소들 둥글게 */
   .fc-daygrid-day-top {
-    @apply !rounded-t-xl;
+    @apply !rounded-t-lg;
   }
 
   .fc-daygrid-day-bottom {
-    @apply !rounded-b-xl;
+    @apply !rounded-b-lg;
   }
 
   /* 날짜 숫자 스타일 */


### PR DESCRIPTION
# 📝 PR 설명

## 변경 사항

팀 캘린더와 개인 캘린더를 `mode` 를 통해 분리하였습니다.
팀 일정 등록 모달의 crud api를 연동하고 추가 UI를 구현하였습니다.

## 상세 설명

- 팀 일정 crud api를 연동하였습니다.
- 메모 input 칸을 추가 구현하였습니다.
- 수정 시, 저장된 날짜(기간)과 시간이 모달에 보여지도록 코드를 수정하였습니다.

## 관련 이슈

<!-- 관련된 이슈 번호를 작성해주세요 (예: #123) -->

- 관련 이슈 : #69
  Closes #69

## 리뷰 해야할 부분

- [ ] 팀 캘린더와 개인 캘린더에서 모두 조회, 추가, 수정, 삭제가 모두 잘 동작하는지 확인
- [ ] 팀 캘린더와 개인 캘린더를 분리하면서 필요한 코드가 삭제되지 않았는지 확인
- [ ] 일정을 수정할 때 기존에 저장된 정보가 모달에 뜨는지 확인

## 스크린샷 (UI 변경이 있는 경우)

<img width="668" height="699" alt="스크린샷 2025-10-13 오후 3 24 46" src="https://github.com/user-attachments/assets/6d9a4c5a-239f-44d8-979e-999feeff4439" />

<img width="667" height="697" alt="스크린샷 2025-10-13 오후 3 24 38" src="https://github.com/user-attachments/assets/0b1b7ae8-5dcd-455a-a66c-dcb403823631" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team calendar mode: view/create/edit/delete team events; personal vs team mode selectable.
  * Added timetable image retrieval.
  * Added description (메모) field to event form.

* **Refactor**
  * Split calendar APIs into personal and team clients and adjusted exports.

* **UI/UX**
  * Date modal pre-fills on edit and preserves time parts when changing dates.
  * Edit submit label changed to "등록"; removed time field labels; spacing/input tweaks.
* **Style**
  * Calendar styling: reduced hover transforms, smaller radii, tighter typography.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->