### PR TITLE
Feat: 팀 일정 카드 및 개인 일정 카드 포멧 통일

### DIFF
--- a/src/pages/PersonalCalendar/components/UpcomingSchedule.tsx
+++ b/src/pages/PersonalCalendar/components/UpcomingSchedule.tsx
@@ -5,8 +5,8 @@ const UpcomingSchedule = () => {
   return (
     <div className="overflow-hidden p-6 bg-white rounded-xl border shadow-lg border-mainBlue/70">
       <div className="flex gap-2 items-center mb-2">
-        <AlarmClock className="w-4 h-4 text-mainBlue" />
-        <h3 className="text-lg font-semibold text-mainBlue">다가오는 일정</h3>
+        <AlarmClock className="w-4.5 h-4.5 text-mainBlue " />
+        <h3 className="text-lg font-semibold">다가오는 일정</h3>
       </div>
       <UpcomingScheduleList />
     </div>

--- a/src/pages/PersonalCalendar/components/UpcomingScheduleItem.tsx
+++ b/src/pages/PersonalCalendar/components/UpcomingScheduleItem.tsx
@@ -1,18 +1,25 @@
 import { ScheduleCard } from '@/components/molecules/ScheduleCard';
 import type { CalendarEvent } from '@/types/calendar';
-import { formatDateTimeShort } from '@/utils/dateTimeUtils';
+import { formatDateWithWeekday, getTimePart } from '@/utils/dateTimeUtils';
 import { Paperclip } from 'lucide-react';
 
 export const UpcomingScheduleItem = ({ event }: { event: CalendarEvent }) => {
+  const date = formatDateWithWeekday(event.start_time);
+  const startTime = getTimePart(event.start_time);
+  const endTime = getTimePart(event.end_time);
+
   const today = new Date();
+  today.setHours(0, 0, 0, 0);
   const targetDate = new Date(event.start_time);
-  const diffTime = Math.abs(targetDate.getTime() - today.getTime());
+  targetDate.setHours(0, 0, 0, 0);
+  const diffTime = targetDate.getTime() - today.getTime();
   const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
   return (
     <ScheduleCard
       title={event.title}
-      dateTime={formatDateTimeShort(event.start_time)}
-      description={event.description}
+      dateTime={`${date} ${startTime}-${endTime}`}
+      description={event.description || undefined}
       descriptionIcon={event.description ? <Paperclip className="w-3.5 h-3.5" /> : undefined}
       dDay={diffDays}
     />

--- a/src/pages/PersonalCalendar/components/UpcomingScheduleList.tsx
+++ b/src/pages/PersonalCalendar/components/UpcomingScheduleList.tsx
@@ -1,6 +1,13 @@
 import { useCalendarStore } from '@/store/calendar';
 import { useEffect } from 'react';
 import { UpcomingScheduleItem } from './UpcomingScheduleItem';
+import type { CalendarEvent } from '@/types/calendar';
+
+const sortByStartTime = (events: CalendarEvent[]) => {
+  return [...events].sort(
+    (a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime(),
+  );
+};
 
 export const UpcomingScheduleList = () => {
   const { upcomingEvents, getUpcomingEvents } = useCalendarStore();
@@ -9,10 +16,12 @@ export const UpcomingScheduleList = () => {
     void getUpcomingEvents();
   }, []);
 
+  const sortedEvents = upcomingEvents ? sortByStartTime(upcomingEvents) : [];
+
   return (
     <div className="space-y-2">
-      {upcomingEvents && upcomingEvents.length > 0 ? (
-        upcomingEvents.map((event) => <UpcomingScheduleItem key={event.event_id} event={event} />)
+      {sortedEvents && sortedEvents.length > 0 ? (
+        sortedEvents.map((event) => <UpcomingScheduleItem key={event.event_id} event={event} />)
       ) : (
         <div className="flex justify-center items-center h-full">
           <p className="text-sm text-gray-500">다가오는 일정이 없습니다.</p>

--- a/src/pages/TeamCalendar/components/UpcomingTeamSchedule.tsx
+++ b/src/pages/TeamCalendar/components/UpcomingTeamSchedule.tsx
@@ -3,11 +3,11 @@ import { UpcomingTeamScheduleList } from '@/pages/TeamCalendar/components/Upcomi
 const UpcomingTeamSchedule = () => {
   return (
     <>
-      <div className="overflow-hidden rounded-xl">
-        <div className="flex flex-col gap-2 mb-2">
-          <h3 className="text-lg font-semibold">팀 주간 일정</h3>
-          <UpcomingTeamScheduleList />
+      <div className="overflow-hidden">
+        <div className="flex gap-2 items-center mb-2">
+          <h3 className="text-lg font-semibold mb-2">다가오는 일정</h3>
         </div>
+        <UpcomingTeamScheduleList />
       </div>
     </>
   );

--- a/src/pages/TeamCalendar/components/UpcomingTeamScheduleItem.tsx
+++ b/src/pages/TeamCalendar/components/UpcomingTeamScheduleItem.tsx
@@ -5,29 +5,19 @@ import { ScheduleCard } from '@/components/molecules/ScheduleCard';
 
 interface UpcomingTeamScheduleItemProps {
   schedule: TeamUpcomingSchedule;
-  showDDay?: boolean;
 }
 
-export const UpcomingTeamScheduleItem = ({
-  schedule,
-  showDDay = false,
-}: UpcomingTeamScheduleItemProps) => {
+export const UpcomingTeamScheduleItem = ({ schedule }: UpcomingTeamScheduleItemProps) => {
   const date = formatDateWithWeekday(schedule.start_time);
   const startTime = getTimePart(schedule.start_time);
   const endTime = getTimePart(schedule.end_time);
 
-  // D-day 계산
-  const calculateDDay = (startTime: string) => {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const targetDate = new Date(startTime);
-    targetDate.setHours(0, 0, 0, 0);
-    const diffTime = targetDate.getTime() - today.getTime();
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-    return diffDays;
-  };
-
-  const dDay = showDDay ? calculateDDay(schedule.start_time) : undefined;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const targetDate = new Date(schedule.start_time);
+  targetDate.setHours(0, 0, 0, 0);
+  const diffTime = targetDate.getTime() - today.getTime();
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
 
   return (
     <ScheduleCard
@@ -35,7 +25,7 @@ export const UpcomingTeamScheduleItem = ({
       dateTime={`${date} ${startTime}-${endTime}`}
       description={schedule.description || undefined}
       descriptionIcon={schedule.description ? <Paperclip className="w-3.5 h-3.5" /> : undefined}
-      dDay={dDay}
+      dDay={diffDays}
     />
   );
 };

--- a/src/pages/TeamCalendar/components/UpcomingTeamScheduleList.tsx
+++ b/src/pages/TeamCalendar/components/UpcomingTeamScheduleList.tsx
@@ -35,7 +35,7 @@ export const UpcomingTeamScheduleList = () => {
   return (
     <div className="space-y-2">
       {sortedSchedules.map((schedule) => (
-        <UpcomingTeamScheduleItem key={schedule.event_id} schedule={schedule} showDDay={true} />
+        <UpcomingTeamScheduleItem key={schedule.event_id} schedule={schedule} />
       ))}
     </div>
   );


### PR DESCRIPTION
# 📝 PR 설명

## 변경 사항

- 팀 일정 카드와 개인 일정 카드의 포멧을 통일하였습니다.
- d-day 오름차순을 적용하였습니다.

## 관련 이슈

<!-- 관련된 이슈 번호를 작성해주세요 (예: #123) -->

- 관련 이슈 : #129
  Closes #129 

