### PR TITLE
Feat: 시간표 저장 api 연동 및 시간표 조회, 수정 UI 구현

### DIFF
--- a/src/apis/constants/endpoints.ts
+++ b/src/apis/constants/endpoints.ts
@@ -12,7 +12,7 @@ export const AUTH_ENDPOINTS = {
 
   SEND_VERIFICATION_CODE: '/api/auth/email/send', // 이메일 인증 코드 발송
   VERITY_VERIFICATION_CODE: '/api/auth/email/verify', // 이메일 인증 코드 검증
-  
+
   SIGNOUT: '/api/members/me',
 } as const;
 
@@ -47,6 +47,7 @@ export const EVERYTIME_ENDPOINTS = {
   TIMETABLES: '/api/everytime/timetables',
   TIMETABLE_DETAIL: '/api/everytime/timetable',
   TIMETABLE_IMAGE: '/api/everytime/timetable',
+  SAVE_LECTURES: '/api/lectures',
 } as const;
 
 export const TEAM_ENDPOINTS = {

--- a/src/apis/services/everytime.ts
+++ b/src/apis/services/everytime.ts
@@ -7,6 +7,8 @@ import type {
   TimetableDetailResponse,
   TimetableImageRequest,
   TimetableImageResponse,
+  SaveLecturesRequest,
+  SaveLecturesResponse,
 } from '@/apis/types/timetable';
 
 export const everytimeAPI = {
@@ -102,6 +104,24 @@ export const everytimeAPI = {
           };
         }
 
+        throw error;
+      });
+  },
+  // 강의 저장
+  saveLectures: (request: SaveLecturesRequest) => {
+    return apiClient
+      .put(EVERYTIME_ENDPOINTS.SAVE_LECTURES, request)
+      .then((response) => {
+        console.log('강의 저장 성공', response.data);
+        return response.data as SaveLecturesResponse;
+      })
+      .catch((error) => {
+        console.error('강의 저장 에러:', error);
+        console.error('에러 상세:', {
+          message: error.message,
+          status: error.response?.status,
+          data: error.response?.data,
+        });
         throw error;
       });
   },

--- a/src/apis/types/timetable.ts
+++ b/src/apis/types/timetable.ts
@@ -42,3 +42,15 @@ export interface SubjectTime {
   endTime: string;
   place: string;
 }
+
+// 강의 저장
+export interface SaveLecturesRequest {
+  startDate: string;
+  endDate: string;
+  timetable: {
+    year: string;
+    semester: string;
+    subjects: Subject[];
+  };
+}
+export type SaveLecturesResponse = TimetableDetailResponse;

--- a/src/pages/Calendar/components/MetaFields.tsx
+++ b/src/pages/Calendar/components/MetaFields.tsx
@@ -2,8 +2,6 @@ import { FormInput } from '@/components/atoms/FormInput';
 import MemberSelectDropdown from '@/pages/Calendar/components/MemberSelectDropdown';
 import { getDatePart } from '@/utils/dateTimeUtils';
 import type { FormData } from '@/hooks/calendar/useFormData';
-import MemberSelectDropdown from '@/pages/Calendar/components/MemberSelectDropdown';
-import { getDatePart } from '@/utils/dateTimeUtils';
 import { useState } from 'react';
 import type { DateRange } from 'react-day-picker';
 

--- a/src/pages/PersonalCalendar/components/LinkStatus.tsx
+++ b/src/pages/PersonalCalendar/components/LinkStatus.tsx
@@ -34,7 +34,7 @@ const LinkStatus = () => {
                 variant="outline"
                 size="sm"
                 noWrapper={true}
-                className="border-mainBlue text-[#1C398E] hover:bg-mainBlue/50 hover:text-white"
+                className="border-none bg-blue-600 text-white hover:bg-blue-700"
               >
                 시간표 수정
               </Button>

--- a/src/pages/PersonalCalendar/index.tsx
+++ b/src/pages/PersonalCalendar/index.tsx
@@ -10,8 +10,10 @@ import TodaySchedule from '@/pages/PersonalCalendar/components/TodaySchedule';
 import UpcomingSchedule from '@/pages/PersonalCalendar/components/UpcomingSchedule';
 import { useClassStore } from '@/store/calendar/useClassStore';
 import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
 const PersonalCalendarPage = () => {
+  const location = useLocation();
   const { teams, isLoading, isSetting, setIsSetting } = useTeam();
   const { leaveTeam } = useLeaveTeam();
   const { deleteTeam } = useDeleteTeam();
@@ -19,7 +21,15 @@ const PersonalCalendarPage = () => {
 
   useEffect(() => {
     void getLectures();
-  }, [getLectures]);
+  }, [location.pathname]);
+
+  useEffect(() => {
+    const handleFocus = () => {
+      void getLectures();
+    };
+    window.addEventListener('focus', handleFocus);
+    return () => window.removeEventListener('focus', handleFocus);
+  }, []);
 
   return (
     <div className="min-h-[calc(100vh-70px)] bg-gradient-to-br from-blue-50 to-indigo-100">

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -1,4 +1,5 @@
 import { AuthInput } from '@/components/atoms/AuthInput';
+import { authAPI } from '@/apis';
 import Button from '@/components/atoms/Button';
 import Logo from '@/components/atoms/Logo';
 import { RouterPath } from '@/routes/path';
@@ -10,7 +11,6 @@ import { toast } from 'react-toastify';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { toast } from 'react-toastify';
 import { z } from 'zod';
 
 const signupSchema = z

--- a/src/pages/TimeTable/components/EverytimeLinkTab.tsx
+++ b/src/pages/TimeTable/components/EverytimeLinkTab.tsx
@@ -1,6 +1,6 @@
 import { FormInput } from '@/components/atoms/FormInput';
 import type { TimetableResponse, TimetableDetailResponse } from '@/apis';
-import { validateTimetableData, getDayOfWeek, formatTime } from '@/utils/timetableUtils';
+import { validateTimetableData } from '@/utils/timetableUtils';
 import TimetableGrid from '@/pages/TimeTable/components/TimatableGrid';
 
 interface EverytimeLinkTabProps {
@@ -76,37 +76,6 @@ const EverytimeLinkTab: React.FC<EverytimeLinkTabProps> = ({
             }
             return <TimetableGrid subjects={timetableDetail.subjects} />;
           })()}
-        </div>
-      )}
-
-      {/* 시간표 상세 정보 */}
-      {timetableDetail && (
-        <div className="mt-4">
-          <label className="block mb-2 text-sm font-bold text-gray-700">
-            시간표 정보
-            {timetableDetail.year &&
-              timetableDetail.semester &&
-              ` (${timetableDetail.year}년 ${timetableDetail.semester}학기)`}
-          </label>
-          <div className="overflow-y-auto border border-gray-200 rounded-md p-3 bg-gray-50">
-            {(() => {
-              const validation = validateTimetableData(timetableDetail.subjects);
-              if (!validation.isValid) {
-                return <div className="text-center text-red-500 py-4">{validation.message}</div>;
-              }
-              return timetableDetail.subjects.map((subject, index) => (
-                <div key={index} className="mb-3 last:mb-0">
-                  <div className="font-semibold text-gray-800 mb-1">{subject.name}</div>
-                  {subject.times.map((time, timeIndex) => (
-                    <div key={timeIndex} className="ml-2 text-sm text-gray-600">
-                      {getDayOfWeek(time.dayOfWeek)} {formatTime(time.startTime)} -{' '}
-                      {formatTime(time.endTime)}
-                    </div>
-                  ))}
-                </div>
-              ));
-            })()}
-          </div>
         </div>
       )}
     </div>

--- a/src/pages/TimeTable/components/EverytimeLinkTab.tsx
+++ b/src/pages/TimeTable/components/EverytimeLinkTab.tsx
@@ -1,6 +1,7 @@
 import { FormInput } from '@/components/atoms/FormInput';
 import type { TimetableResponse, TimetableDetailResponse } from '@/apis';
 import { validateTimetableData, getDayOfWeek, formatTime } from '@/utils/timetableUtils';
+import TimetableGrid from '@/pages/TimeTable/components/TimatableGrid';
 
 interface EverytimeLinkTabProps {
   everytimeTable: string;
@@ -58,6 +59,24 @@ const EverytimeLinkTab: React.FC<EverytimeLinkTabProps> = ({
 
       {timetableError && (
         <div className="m-3 text-sm text-center text-red-600">{timetableError}</div>
+      )}
+
+      {timetableDetail && (
+        <div className="mt-4">
+          <label className="block mb-2 text-sm font-bold text-gray-700">
+            시간표 정보
+            {timetableDetail.year &&
+              timetableDetail.semester &&
+              ` (${timetableDetail.year}년 ${timetableDetail.semester}학기)`}
+          </label>
+          {(() => {
+            const validation = validateTimetableData(timetableDetail.subjects);
+            if (!validation.isValid) {
+              return <div className="text-center text-red-500 py-4">{validation.message}</div>;
+            }
+            return <TimetableGrid subjects={timetableDetail.subjects} />;
+          })()}
+        </div>
       )}
 
       {/* 시간표 상세 정보 */}

--- a/src/pages/TimeTable/components/ImageUploadTab.tsx
+++ b/src/pages/TimeTable/components/ImageUploadTab.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ImageInput from '@/pages/TimeTable/components/ImageInput';
 import type { TimetableImageResponse } from '@/apis';
-import { validateTimetableData, getDayOfWeek, formatTime } from '@/utils/timetableUtils';
+import { validateTimetableData } from '@/utils/timetableUtils';
 import TimetableGrid from '@/pages/TimeTable/components/TimatableGrid';
 
 interface ImageUploadTabProps {
@@ -63,36 +63,6 @@ const ImageUploadTab: React.FC<ImageUploadTabProps> = ({
             }
             return <TimetableGrid subjects={parsedTimetable.subjects} />;
           })()}
-        </div>
-      )}
-      {/* 파싱된 시간표 정보 */}
-      {parsedTimetable && (
-        <div className="mt-4">
-          <label className="block mb-2 text-sm font-bold text-gray-700">
-            시간표 정보
-            {parsedTimetable.year &&
-              parsedTimetable.semester &&
-              ` (${parsedTimetable.year} ${parsedTimetable.semester})`}
-          </label>
-          <div className="max-h-60 overflow-y-auto border border-gray-200 rounded-md p-3 bg-gray-50">
-            {(() => {
-              const validation = validateTimetableData(parsedTimetable.subjects);
-              if (!validation.isValid) {
-                return <div className="text-center text-red-500 py-4">{validation.message}</div>;
-              }
-              return parsedTimetable.subjects.map((subject, index) => (
-                <div key={index} className="mb-3 last:mb-0">
-                  <div className="font-semibold text-gray-800 mb-1">{subject.name}</div>
-                  {subject.times.map((time, timeIndex) => (
-                    <div key={timeIndex} className="ml-2 text-sm text-gray-600">
-                      {getDayOfWeek(time.dayOfWeek)} {formatTime(time.startTime)} -{' '}
-                      {formatTime(time.endTime)}
-                    </div>
-                  ))}
-                </div>
-              ));
-            })()}
-          </div>
         </div>
       )}
     </div>

--- a/src/pages/TimeTable/components/ImageUploadTab.tsx
+++ b/src/pages/TimeTable/components/ImageUploadTab.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ImageInput from '@/pages/TimeTable/components/ImageInput';
 import type { TimetableImageResponse } from '@/apis';
 import { validateTimetableData, getDayOfWeek, formatTime } from '@/utils/timetableUtils';
+import TimetableGrid from '@/pages/TimeTable/components/TimatableGrid';
 
 interface ImageUploadTabProps {
   selectedImage: File | null;
@@ -46,6 +47,24 @@ const ImageUploadTab: React.FC<ImageUploadTabProps> = ({
       {/* 이미지 파싱 에러 */}
       {imageParseError && <div className="mt-2 text-center text-red-600">{imageParseError}</div>}
 
+      {/* 파싱된 시간표 정보 */}
+      {parsedTimetable && (
+        <div className="mt-4">
+          <label className="block mb-2 text-sm font-bold text-gray-700">
+            시간표 정보
+            {parsedTimetable.year &&
+              parsedTimetable.semester &&
+              ` (${parsedTimetable.year} ${parsedTimetable.semester})`}
+          </label>
+          {(() => {
+            const validation = validateTimetableData(parsedTimetable.subjects);
+            if (!validation.isValid) {
+              return <div className="text-center text-red-500 py-4">{validation.message}</div>;
+            }
+            return <TimetableGrid subjects={parsedTimetable.subjects} />;
+          })()}
+        </div>
+      )}
       {/* 파싱된 시간표 정보 */}
       {parsedTimetable && (
         <div className="mt-4">

--- a/src/pages/TimeTable/components/TimatableGrid.tsx
+++ b/src/pages/TimeTable/components/TimatableGrid.tsx
@@ -1,0 +1,176 @@
+import { useMemo } from 'react';
+import type { Subject } from '@/apis';
+import { WEEKDAYS_MON_FIRST } from '@/constants';
+
+interface TimetableGirdProps {
+  subjects: Subject[];
+}
+
+const TimetableGrid: React.FC<TimetableGirdProps> = ({ subjects }) => {
+  const START_HOUR = 9;
+  const MIN_END_HOUR = 23;
+  const CONTAINER_HEIGHT = 600;
+
+  //시간 -> 분
+  const convertTimetoMinutes = (time: string): number => {
+    const [hours, minutes] = time.split(':').map(Number);
+    return hours * 60 + minutes;
+  };
+
+  //최대 종료 시간 계산
+  const endHour = useMemo(() => {
+    let maxTime = START_HOUR * 60;
+
+    subjects.forEach((subject) => {
+      subject.times.forEach((time) => {
+        const end = convertTimetoMinutes(time.endTime);
+        maxTime = Math.max(maxTime, end);
+      });
+    });
+    return Math.max(MIN_END_HOUR, Math.ceil(maxTime / 60));
+  }, [subjects]);
+
+  //시간대 생성
+  const timeSlots = useMemo(() => {
+    const slots: string[] = [];
+    for (let hour = START_HOUR; hour < endHour; hour++) {
+      slots.push(`${hour.toString().padStart(2, '0')}:00`);
+    }
+    return slots;
+  }, [endHour]);
+
+  //시간 -> height
+  const heightPerHour = CONTAINER_HEIGHT / (endHour - START_HOUR);
+  const heightPerMinute = heightPerHour / 60;
+
+  //수업 위치 및 높이 계산
+  const getSubjectPosition = (time: any) => {
+    const start = convertTimetoMinutes(time.startTime);
+    const end = convertTimetoMinutes(time.endTime);
+    const top = (start - START_HOUR * 60) * heightPerMinute;
+    const height = (end - start) * heightPerMinute;
+
+    return { top, height };
+  };
+
+  //요일별 수업 그룹화
+  const dayOfWeekToDay = useMemo(() => {
+    const grouped: { [key: number]: Array<{ subject: Subject; time: any }> } = {};
+    for (let day = 0; day < 5; day++) {
+      grouped[day] = [];
+    }
+    subjects.forEach((subject) => {
+      subject.times.forEach((time) => {
+        if (time.dayOfWeek >= 1 && time.dayOfWeek <= 5) {
+          const dayIndex = time.dayOfWeek - 1;
+          if (!grouped[dayIndex]) grouped[dayIndex] = [];
+          grouped[dayIndex].push({ subject, time });
+        }
+      });
+    });
+    return grouped;
+  }, [subjects]);
+
+  //색상 선언
+  const getSubjectColor = (index: number) => {
+    const colors = [
+      'bg-blue-100 text-blue-800',
+      'bg-green-100 text-green-800',
+      'bg-purple-100 text-purple-800',
+      'bg-orange-100 text-orange-800',
+      'bg-pink-100 text-pink-800',
+      'bg-yellow-100 text-yellow-800',
+      'bg-indigo-100 text-indigo-800',
+      'bg-red-100 text-red-800',
+    ];
+    return colors[index % colors.length];
+  };
+
+  // 과목별 색상 인덱스 계산
+  const subjectColorMap = useMemo(() => {
+    const map = new Map<string, number>();
+    let colorIndex = 0;
+    subjects.forEach((subject) => {
+      if (!map.has(subject.name)) {
+        map.set(subject.name, colorIndex++);
+      }
+    });
+    return map;
+  }, [subjects]);
+
+  return (
+    <div className="relative w-full border border-gray-200 rounded-md bg-white overflow-hidden">
+      {/* 요일 헤더 */}
+      <div className="flex border-gray-200">
+        <div className="w-12 border-r border-gray-200"></div>
+        {WEEKDAYS_MON_FIRST.slice(0, 5).map((day, index) => (
+          <div
+            key={index}
+            className="flex-1 py-2 text-center text-sm font-semibold text-gray-700 border-r border-gray-200 last:border-r-0"
+          >
+            {day}
+          </div>
+        ))}
+      </div>
+      {/* 시간표 그리드 */}
+      <div className="relative" style={{ height: `${CONTAINER_HEIGHT}px` }}>
+        {/* 시간 라벨 */}
+        <div className="absolute -mt-2 left-0 top-0 bottom-0 w-12 border-r border-gray-200">
+          {timeSlots.map((time, index) => (
+            <div
+              key={time}
+              className="absolute left-0 right-0 text-xs text-gray-500 text-right pr-2"
+              style={{ top: `${index * heightPerHour}px`, height: `${heightPerHour}px` }}
+            >
+              {time}
+            </div>
+          ))}
+        </div>
+        {/* 요일별 컬럼 */}
+        <div className="ml-12 flex">
+          {[0, 1, 2, 3, 4].map((dayIndex) => (
+            <div
+              key={dayIndex}
+              className="flex-1 relative border-r border-gray-200 last:border-r-0"
+              style={{ height: `${CONTAINER_HEIGHT}px` }}
+            >
+              {/* 시간 구분선 */}
+              {timeSlots.map((time, index) => (
+                <div
+                  key={time}
+                  className="absolute left-0 right-0 border-b border-gray-200"
+                  style={{ top: `${index * heightPerHour}px` }}
+                />
+              ))}
+              {/* 수업 블록 */}
+              {dayOfWeekToDay[dayIndex]?.map((item, idx) => {
+                const { top, height } = getSubjectPosition(item.time);
+                const colorIndex = subjectColorMap.get(item.subject.name) || 0;
+                const colorClass = getSubjectColor(colorIndex);
+                return (
+                  <div
+                    key={`${item.subject.name}-${dayIndex}-${idx}`}
+                    className={`absolute left-1 mt-1 right-1 text-center py-2 text-xs ${colorClass} rounded-sm overflow-hidden`}
+                    style={{
+                      top: `${top}px`,
+                      height: `${Math.max(height, 20)}px`,
+                      minHeight: '20px',
+                    }}
+                    title={`${item.subject.name} (${item.subject.professor}) - ${item.time.startTime.substring(0, 5)} - ${item.time.endTime.substring(0, 5)}`}
+                  >
+                    <div className="font-semibold truncate">{item.subject.name}</div>
+                    <div className="text-xs opacity-75 truncate">
+                      {item.time.startTime.substring(0, 5)} - {item.time.endTime.substring(0, 5)}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TimetableGrid;

--- a/src/pages/TimeTable/components/TimatableGrid.tsx
+++ b/src/pages/TimeTable/components/TimatableGrid.tsx
@@ -74,14 +74,14 @@ const TimetableGrid: React.FC<TimetableGirdProps> = ({ subjects }) => {
   //색상 선언
   const getSubjectColor = (index: number) => {
     const colors = [
-      'bg-blue-100 text-blue-800',
-      'bg-green-100 text-green-800',
+      'bg-blue-50 text-blue-800',
+      'bg-blue-100 text-blue-900',
+      'bg-blue-200 text-blue-900',
+      'bg-indigo-50 text-indigo-800',
+      'bg-indigo-100 text-indigo-800',
+      'bg-indigo-200 text-indigo-800',
       'bg-purple-100 text-purple-800',
       'bg-orange-100 text-orange-800',
-      'bg-pink-100 text-pink-800',
-      'bg-yellow-100 text-yellow-800',
-      'bg-indigo-100 text-indigo-800',
-      'bg-red-100 text-red-800',
     ];
     return colors[index % colors.length];
   };
@@ -150,7 +150,7 @@ const TimetableGrid: React.FC<TimetableGirdProps> = ({ subjects }) => {
                 return (
                   <div
                     key={`${item.subject.name}-${dayIndex}-${idx}`}
-                    className={`absolute left-1 mt-1 right-1 text-center py-2 text-xs ${colorClass} rounded-sm overflow-hidden`}
+                    className={`absolute left-0 right-0 text-center py-2 text-xs ${colorClass} overflow-hidden`}
                     style={{
                       top: `${top}px`,
                       height: `${Math.max(height, 20)}px`,

--- a/src/pages/TimeTable/components/TimetableEdit.tsx
+++ b/src/pages/TimeTable/components/TimetableEdit.tsx
@@ -192,7 +192,7 @@ const TimetableEditForm: React.FC<TimetableEditFormProps> = ({ subjects, onSubje
                         variant="primary"
                         size="md"
                         noWrapper={true}
-                        className="py-2 mb-1.5 bg-red-500 hover:bg-red-600 w-full"
+                        className="py-2 mb-1.5 bg-gray-400 hover:bg-gray-500 w-full"
                       />
                     </div>
                   )}

--- a/src/pages/TimeTable/components/TimetableEdit.tsx
+++ b/src/pages/TimeTable/components/TimetableEdit.tsx
@@ -91,7 +91,7 @@ const TimetableEditForm: React.FC<TimetableEditFormProps> = ({ subjects, onSubje
       {subjects.map((subject, subjectIndex) => (
         <div key={subjectIndex} className="p-4 border border-gray-200 rounded-lg">
           {/* 과목 기본 정보 */}
-          <div className="flex flex-col md:flex-row gap-2 lg:items-end">
+          <div className="flex flex-col md:flex-row gap-2 md:items-end lg:items-end">
             <FormInput
               id={`subject-name-${subjectIndex}`}
               label="과목명"

--- a/src/pages/TimeTable/components/TimetableEdit.tsx
+++ b/src/pages/TimeTable/components/TimetableEdit.tsx
@@ -1,0 +1,211 @@
+import type { Subject, SubjectTime } from '@/apis/types/timetable';
+import { FormInput } from '@/components/atoms/FormInput';
+import Button from '@/components/atoms/Button';
+import { WEEKDAYS_MON_FIRST } from '@/constants';
+import { formatTime, formatTimeToSeconds } from '@/utils/timetableUtils';
+
+interface TimetableEditFormProps {
+  subjects: Subject[];
+  onSubjectsChange: (subjects: Subject[]) => void;
+}
+
+const TimetableEditForm: React.FC<TimetableEditFormProps> = ({ subjects, onSubjectsChange }) => {
+  // 과목 추가
+  const handleAddSubject = () => {
+    const newSubject: Subject = {
+      name: '',
+      professor: '',
+      credit: 0,
+      times: [
+        {
+          dayOfWeek: 1,
+          startTime: '09:00:00',
+          endTime: '10:00:00',
+          place: '',
+        },
+      ],
+    };
+    onSubjectsChange([...subjects, newSubject]);
+  };
+
+  // 과목 삭제
+  const handleDeleteSubject = (index: number) => {
+    const newSubjects = subjects.filter((_, i) => i !== index);
+    onSubjectsChange(newSubjects);
+  };
+
+  // 과목 필드 업데이트
+  const handleSubjectFieldChange = (
+    index: number,
+    field: 'name' | 'professor' | 'credit',
+    value: string | number,
+  ) => {
+    const newSubjects = [...subjects];
+    newSubjects[index] = {
+      ...newSubjects[index],
+      [field]: value,
+    };
+    onSubjectsChange(newSubjects);
+  };
+
+  // 시간 추가
+  const handleAddTime = (subjectIndex: number) => {
+    const newSubjects = [...subjects];
+    const newTime: SubjectTime = {
+      dayOfWeek: 1,
+      startTime: '09:00:00',
+      endTime: '10:00:00',
+      place: '',
+    };
+    newSubjects[subjectIndex].times.push(newTime);
+    onSubjectsChange(newSubjects);
+  };
+
+  // 시간 삭제
+  const handleDeleteTime = (subjectIndex: number, timeIndex: number) => {
+    const newSubjects = [...subjects];
+    newSubjects[subjectIndex].times = newSubjects[subjectIndex].times.filter(
+      (_, i) => i !== timeIndex,
+    );
+    onSubjectsChange(newSubjects);
+  };
+
+  // 시간 필드 업데이트
+  const handleTimeFieldChange = (
+    subjectIndex: number,
+    timeIndex: number,
+    field: 'dayOfWeek' | 'startTime' | 'endTime' | 'place',
+    value: string | number,
+  ) => {
+    const newSubjects = [...subjects];
+    newSubjects[subjectIndex].times[timeIndex] = {
+      ...newSubjects[subjectIndex].times[timeIndex],
+      [field]: value,
+    };
+    onSubjectsChange(newSubjects);
+  };
+
+  return (
+    <div className="mt-4 space-y-4">
+      {/* 과목 목록 */}
+      {subjects.map((subject, subjectIndex) => (
+        <div key={subjectIndex} className="p-4 border border-gray-200 rounded-lg">
+          {/* 과목 기본 정보 */}
+          <div className="flex flex-col md:flex-row gap-2 lg:items-end">
+            <FormInput
+              id={`subject-name-${subjectIndex}`}
+              label="과목명"
+              value={subject.name}
+              onChange={(value) => handleSubjectFieldChange(subjectIndex, 'name', value)}
+              required
+              className="w-full md:flex-1"
+            />
+            <FormInput
+              id={`subject-professor-${subjectIndex}`}
+              label="교수명"
+              value={subject.professor || ''}
+              onChange={(value) => handleSubjectFieldChange(subjectIndex, 'professor', value)}
+            />
+            <Button
+              onClick={() => handleAddTime(subjectIndex)}
+              text="시간 추가"
+              variant="outline"
+              size="md"
+              noWrapper={true}
+              className="mb-1"
+            />
+            <Button
+              onClick={() => handleDeleteSubject(subjectIndex)}
+              text="과목 삭제"
+              variant="primary"
+              size="md"
+              noWrapper={true}
+              className="mb-1 bg-red-500 hover:bg-red-600"
+            />
+          </div>
+
+          {/* 시간 정보 */}
+          <div className="space-y-3 mt-1 ">
+            {subject.times.map((time, timeIndex) => (
+              <div key={timeIndex} className="p-3 border border-gray-300 rounded-md bg-white">
+                <div className="grid grid-cols-1 md:grid-cols-5 gap-3 items-end">
+                  <FormInput
+                    id={`time-day-${subjectIndex}-${timeIndex}`}
+                    label="요일"
+                    type="select"
+                    value={time.dayOfWeek.toString()}
+                    onChange={(value) =>
+                      handleTimeFieldChange(subjectIndex, timeIndex, 'dayOfWeek', parseInt(value))
+                    }
+                    options={WEEKDAYS_MON_FIRST.slice(0, 5).map((day, index) => ({
+                      label: day,
+                      value: (index + 1).toString(),
+                    }))}
+                  />
+
+                  <FormInput
+                    id={`time-start-${subjectIndex}-${timeIndex}`}
+                    label="시작시간"
+                    type="time"
+                    value={formatTime(time.startTime)}
+                    onChange={(value) =>
+                      handleTimeFieldChange(
+                        subjectIndex,
+                        timeIndex,
+                        'startTime',
+                        formatTimeToSeconds(value),
+                      )
+                    }
+                    required
+                  />
+
+                  <FormInput
+                    id={`time-end-${subjectIndex}-${timeIndex}`}
+                    label="종료시간"
+                    type="time"
+                    value={formatTime(time.endTime)}
+                    onChange={(value) =>
+                      handleTimeFieldChange(
+                        subjectIndex,
+                        timeIndex,
+                        'endTime',
+                        formatTimeToSeconds(value),
+                      )
+                    }
+                    required
+                  />
+
+                  <FormInput
+                    id={`time-place-${subjectIndex}-${timeIndex}`}
+                    label="장소"
+                    value={time.place || ''}
+                    onChange={(value) =>
+                      handleTimeFieldChange(subjectIndex, timeIndex, 'place', value)
+                    }
+                    className="[&_input]:py-2"
+                  />
+                  {subject.times.length > 0 && (
+                    <div className="flex items-end">
+                      <Button
+                        onClick={() => handleDeleteTime(subjectIndex, timeIndex)}
+                        text="시간 삭제"
+                        variant="primary"
+                        size="md"
+                        noWrapper={true}
+                        className="py-2 mb-1.5 bg-red-500 hover:bg-red-600 w-full"
+                      />
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+
+      <Button onClick={handleAddSubject} text="+ 과목 추가" variant="outline" className="w-full" />
+    </div>
+  );
+};
+
+export default TimetableEditForm;

--- a/src/pages/TimeTable/index.tsx
+++ b/src/pages/TimeTable/index.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import TimetableEdit from '@/pages/TimeTable/components/TimetableEdit';
 import { everytimeAPI } from '@/apis';
 import type { Subject } from '@/apis/types/timetable';
+import ConfirmModal from '@/components/atoms/ConfirmModal';
 
 const TimeTablePage = () => {
   const navigate = useNavigate();
@@ -24,6 +25,10 @@ const TimeTablePage = () => {
   const [editedSubjects, setEditedSubjects] = useState<Subject[]>([]);
   const [originalSubjects, setOriginalSubjects] = useState<Subject[]>([]);
   const [isSaving, setIsSaving] = useState(false);
+
+  //모달
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+  const [pendingTab, setPendingTab] = useState<'image' | 'link' | null>(null);
 
   // 현재 시간표 데이터 가져오기
   const getCurrentSubjects = (): Subject[] => {
@@ -51,18 +56,36 @@ const TimeTablePage = () => {
 
   const handleTabChange = (tab: 'image' | 'link') => {
     if (isEditMode) {
-      const hasChanges = JSON.stringify(editedSubjects) !== JSON.stringify(getCurrentSubjects());
+      const hasChanges = JSON.stringify(editedSubjects) !== JSON.stringify(originalSubjects);
       if (hasChanges) {
-        const confirm = window.confirm(
-          '수정 중인 내용이 있습니다. 탭을 전환하면 수정 내용이 사라집니다. 계속하시겠습니까?',
-        );
-        if (!confirm) return;
+        setPendingTab(tab);
+        setIsConfirmModalOpen(true);
+        return;
       }
+      // 변경사항이 없으면 바로 탭 전환
       setIsEditMode(false);
       setEditedSubjects([]);
       setOriginalSubjects([]);
     }
     setActiveTab(tab);
+  };
+
+  //모달 확인
+  const handleConfirmTabChange = () => {
+    if (pendingTab) {
+      setIsEditMode(false);
+      setEditedSubjects([]);
+      setOriginalSubjects([]);
+      setActiveTab(pendingTab);
+      setPendingTab(null);
+    }
+    setIsConfirmModalOpen(false);
+  };
+
+  //모달 취소
+  const handleCancelTabChange = () => {
+    setIsConfirmModalOpen(false);
+    setPendingTab(null);
   };
 
   // 저장
@@ -245,6 +268,16 @@ const TimeTablePage = () => {
           disabled={isSaving || getCurrentSubjects().length === 0}
         />
       </div>
+      <ConfirmModal
+        isOpen={isConfirmModalOpen}
+        title="시간표 등록 탭 전환 확인"
+        message={`수정 중인 내용이 있습니다.
+        탭을 전환하면 수정 내용이 사라집니다. 계속하시겠습니까?`}
+        onConfirm={handleConfirmTabChange}
+        onClose={handleCancelTabChange}
+        confirmText="계속"
+        confirmButtonColor="bg-red-500 hover:bg-red-600"
+      />
     </>
   );
 };

--- a/src/pages/TimeTable/index.tsx
+++ b/src/pages/TimeTable/index.tsx
@@ -7,6 +7,9 @@ import ImageUploadTab from '@/pages/TimeTable/components/ImageUploadTab';
 import { RouterPath } from '@/routes/path';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import TimetableEdit from '@/pages/TimeTable/components/TimetableEdit';
+import { everytimeAPI } from '@/apis';
+import type { Subject } from '@/apis/types/timetable';
 
 const TimeTablePage = () => {
   const navigate = useNavigate();
@@ -15,6 +18,73 @@ const TimeTablePage = () => {
   const [startDate, setStartDate] = useState<Date>(new Date('2025-03-01'));
   const [endDate, setEndDate] = useState<Date>(new Date('2025-12-21'));
   const [everytimeTable, setEverytimeTable] = useState<string>('');
+
+  //시간표 수정
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [editedSubjects, setEditedSubjects] = useState<Subject[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // 현재 시간표 데이터 가져오기
+  const getCurrentSubjects = (): Subject[] => {
+    if (activeTab === 'image' && parsedTimetable) {
+      return parsedTimetable.subjects;
+    }
+    if (activeTab === 'link' && timetableDetail) {
+      return timetableDetail.subjects;
+    }
+    return [];
+  };
+
+  // 수정 모드 토글
+  const handleToggleEdit = () => {
+    if (!isEditMode) {
+      setEditedSubjects([...getCurrentSubjects()]);
+    }
+    setIsEditMode(!isEditMode);
+  };
+
+  // 저장
+  const handleSave = async () => {
+    const currentSubjects = isEditMode ? editedSubjects : getCurrentSubjects();
+
+    if (currentSubjects.length === 0) {
+      alert('저장할 시간표가 없습니다.');
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const timetable =
+        activeTab === 'image' && parsedTimetable
+          ? parsedTimetable
+          : activeTab === 'link' && timetableDetail
+            ? timetableDetail
+            : null;
+
+      if (!timetable) {
+        alert('시간표 정보가 없습니다.');
+        return;
+      }
+      await everytimeAPI.saveLectures({
+        startDate: startDate.toISOString().split('T')[0],
+        endDate: endDate.toISOString().split('T')[0],
+        timetable: {
+          year: timetable.year,
+          semester: timetable.semester,
+          subjects: currentSubjects,
+        },
+      });
+
+      alert('시간표가 저장되었습니다.');
+      localStorage.setItem('timetableLinked', 'true');
+      navigate(RouterPath.HOME.DEFAULT);
+    } catch (error) {
+      console.error('시간표 저장 실패:', error);
+      alert('시간표 저장에 실패했습니다.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
 
   // 시간표 데이터 hook
   const {
@@ -131,6 +201,24 @@ const TimeTablePage = () => {
             timetableDetail={timetableDetail}
           />
         )}
+
+        {getCurrentSubjects().length > 0 && (
+          <div className="mt-4">
+            <Button
+              onClick={handleToggleEdit}
+              text={isEditMode ? '수정 취소' : '수정'}
+              variant={isEditMode ? 'outline' : 'primary'}
+              className="w-full"
+            />
+          </div>
+        )}
+
+        {isEditMode && (
+          <div className="mt-4 p-4 border border-gray-300 rounded-lg bg-white">
+            <h3 className="text-lg font-semibold text-gray-800 mb-4">시간표 수정</h3>
+            <TimetableEdit subjects={editedSubjects} onSubjectsChange={setEditedSubjects} />
+          </div>
+        )}
         {/* 날짜 입력 필드 */}
         <div className="mt-6 space-y-3">
           <div className="flex flex-row space-x-2">
@@ -157,7 +245,12 @@ const TimeTablePage = () => {
             />
           </div>
         </div>
-        <Button onClick={handleSubmit} text="등록하기" className="flex justify-center w-full" />
+        <Button
+          onClick={handleSave}
+          text={isSaving ? '등록 중' : '등록하기'}
+          className="flex justify-center w-full"
+          disabled={isSaving || getCurrentSubjects().length === 0}
+        />
       </div>
     </>
   );

--- a/src/pages/TimeTable/index.tsx
+++ b/src/pages/TimeTable/index.tsx
@@ -22,6 +22,7 @@ const TimeTablePage = () => {
   //시간표 수정
   const [isEditMode, setIsEditMode] = useState(false);
   const [editedSubjects, setEditedSubjects] = useState<Subject[]>([]);
+  const [originalSubjects, setOriginalSubjects] = useState<Subject[]>([]);
   const [isSaving, setIsSaving] = useState(false);
 
   // 현재 시간표 데이터 가져오기
@@ -38,9 +39,30 @@ const TimeTablePage = () => {
   // 수정 모드 토글
   const handleToggleEdit = () => {
     if (!isEditMode) {
+      const currentSubjects = getCurrentSubjects();
       setEditedSubjects([...getCurrentSubjects()]);
+      setOriginalSubjects([...currentSubjects]);
+    } else {
+      //수정 취소 시 원본으로 되돌리기
+      setEditedSubjects([...originalSubjects]);
     }
     setIsEditMode(!isEditMode);
+  };
+
+  const handleTabChange = (tab: 'image' | 'link') => {
+    if (isEditMode) {
+      const hasChanges = JSON.stringify(editedSubjects) !== JSON.stringify(getCurrentSubjects());
+      if (hasChanges) {
+        const confirm = window.confirm(
+          '수정 중인 내용이 있습니다. 탭을 전환하면 수정 내용이 사라집니다. 계속하시겠습니까?',
+        );
+        if (!confirm) return;
+      }
+      setIsEditMode(false);
+      setEditedSubjects([]);
+      setOriginalSubjects([]);
+    }
+    setActiveTab(tab);
   };
 
   // 저장
@@ -124,42 +146,13 @@ const TimeTablePage = () => {
     }
   };
 
-  //데이터 확인용 콘솔
-  const handleSubmit = () => {
-    localStorage.setItem('timetableLinked', 'true');
-    if (selectedTimetable) {
-      console.log('선택된 시간표:', selectedTimetable);
-      console.log('시간표 상세 정보:', timetableDetail);
-      console.log('시간표 등록:', {
-        selectedImage,
-        startDate,
-        endDate,
-        timetableInfo: selectedTimetable,
-        timetableDetail,
-        everytimeUrl: everytimeTable,
-      });
-      navigate(RouterPath.HOME.DEFAULT);
-    } else if (parsedTimetable) {
-      console.log('파싱된 시간표:', parsedTimetable);
-      console.log('시간표 등록:', {
-        selectedImage,
-        startDate,
-        endDate,
-        parsedTimetable,
-      });
-    } else {
-      console.log('시간표 등록:', { selectedImage, startDate, endDate });
-      navigate(RouterPath.HOME.DEFAULT);
-    }
-  };
-
   return (
     <>
       <div className="p-3 m-1 mx-auto max-w-4xl rounded-lg border-gray-200 /border">
         {/* 탭 버튼 */}
         <div className="flex mb-6 border-b border-gray-200">
           <button
-            onClick={() => setActiveTab('image')}
+            onClick={() => handleTabChange('image')}
             className={`px-6 py-3 font-medium transition-colors ${
               activeTab === 'image'
                 ? 'border-b-2 text-blue-600'
@@ -169,7 +162,7 @@ const TimeTablePage = () => {
             이미지로 등록
           </button>
           <button
-            onClick={() => setActiveTab('link')}
+            onClick={() => handleTabChange('link')}
             className={`px-6 py-3 font-medium transition-colors ${
               activeTab === 'link'
                 ? 'border-b-2 text-blue-600'

--- a/src/utils/timetableUtils.ts
+++ b/src/utils/timetableUtils.ts
@@ -42,3 +42,17 @@ export const getDayOfWeek = (dayOfWeek: number) => {
 export const formatTime = (time: string) => {
   return time.substring(0, 5);
 };
+
+/**
+ * 시간 문자열을 HH:MM:SS 형식으로 포맷팅 (input에서 사용)
+ * @param time 시간 문자열 (HH:MM 또는 HH:MM:SS)
+ * @returns HH:MM:SS 형식의 시간 문자열
+ */
+export const formatTimeToSeconds = (time: string): string => {
+  if (time.length === 5) {
+    // "HH:MM" 형식이면 "HH:MM:SS"로 변환
+    return `${time}:00`;
+  }
+  // "HH:MM:SS" 형식이면 그대로 반환
+  return time;
+};


### PR DESCRIPTION
# 📝 PR 설명

## 변경 사항

- 시간표 조회 및 수정 ui를 구현하고 시간표 저장 api를 연동하였습니다.

## 상세 설명

<!-- 변경 사항에 대한 자세한 설명을 작성해주세요 -->
- 시간표 조회 ui를 구현하였습니다.
<img width="915" height="788" alt="스크린샷 2025-11-05 오후 8 20 19" src="https://github.com/user-attachments/assets/0586e456-67bf-4441-9798-46b0849a6200" />

- 시간표 수정 ui를 구현하였습니다.

<img width="893" height="758" alt="스크린샷 2025-11-05 오후 8 20 31" src="https://github.com/user-attachments/assets/a0506eaf-6641-479c-afe4-9b77c089ef66" />
를 구현하였습니다.

- 시간표 수정 도중 탭 전환 시 확인 모달을 띄우도록 구현하였습니다.
<img width="576" height="300" alt="스크린샷 2025-11-05 오후 8 20 47" src="https://github.com/user-attachments/assets/c1cdb131-04be-472e-9b43-7720c9a3baba" />

- 시간표 저장 api를 연동하였습니다.
- 반응형 동작을 확인하였습니다.

## 관련 이슈

<!-- 관련된 이슈 번호를 작성해주세요 (예: #123) -->

- 관련 이슈 : #154 
  Closes #154 

## 리뷰 해야할 부분

- [ ] 디자인 및 UX 코멘트 환영 !
- [ ] 반응형 자연스러운지 확인
- [ ] 불필요한 코드는 없는지 확인

## 스크린샷 (UI 변경이 있는 경우)

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
<img width="1203" height="795" alt="스크린샷 2025-11-05 오후 8 19 32" src="https://github.com/user-attachments/assets/c6e9c6a1-aa5d-4047-bd97-bec335e357f2" />

