### PR TITLE
Refactor: 다가오는 일정 시간순 정렬 처리 제거

### DIFF
--- a/src/hooks/team/useTeamChat.ts
+++ b/src/hooks/team/useTeamChat.ts
@@ -16,13 +16,6 @@ interface ErrorResponse {
 
 type WebSocketMessage = NewMessageResponse | ErrorResponse;
 
-//메세지 시간순 정렬
-const sortMessagesByTime = (messages: ChatMessage[]): ChatMessage[] => {
-  return [...messages].sort(
-    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
-  );
-};
-
 export const useTeamChat = (teamId: number) => {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isConnected, setIsConnected] = useState(false);
@@ -42,14 +35,13 @@ export const useTeamChat = (teamId: number) => {
     setIsLoadingMessages(true);
     try {
       const response = await chatAPI.getChatMessages({ teamId });
-      const sortedMessages = sortMessagesByTime(response.messages);
-      setMessages(sortedMessages);
+      setMessages(response.messages);
       setHasMore(response.hasNext);
       setNextCursor(response.nextCursor);
 
       const lastReadId = localStorage.getItem(`team_${teamId}_lastRead`);
       if (lastReadId && user?.user_id) {
-        const unreadMessages = sortedMessages.filter(
+        const unreadMessages = response.messages.filter(
           (msg) => msg.id > Number(lastReadId) && String(msg.senderId) !== String(user.user_id),
         );
         setUnReadCount(unreadMessages.length);
@@ -69,9 +61,8 @@ export const useTeamChat = (teamId: number) => {
     setIsLoadingMessages(true);
     try {
       const response = await chatAPI.getChatMessages({ teamId, cursor: nextCursor });
-      const sortedMessages = sortMessagesByTime(response.messages);
 
-      setMessages((prev) => [...sortedMessages, ...prev]);
+      setMessages((prev) => [...response.messages, ...prev]);
       setHasMore(response.hasNext);
       setNextCursor(response.nextCursor);
     } catch (error) {

--- a/src/pages/PersonalCalendar/components/UpcomingScheduleList.tsx
+++ b/src/pages/PersonalCalendar/components/UpcomingScheduleList.tsx
@@ -1,13 +1,6 @@
 import { useCalendarStore } from '@/store/calendar';
 import { useEffect } from 'react';
 import { UpcomingScheduleItem } from './UpcomingScheduleItem';
-import type { CalendarEvent } from '@/types/calendar';
-
-const sortByStartTime = (events: CalendarEvent[]) => {
-  return [...events].sort(
-    (a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime(),
-  );
-};
 
 export const UpcomingScheduleList = () => {
   const { upcomingEvents, getUpcomingEvents } = useCalendarStore();
@@ -16,12 +9,10 @@ export const UpcomingScheduleList = () => {
     void getUpcomingEvents();
   }, []);
 
-  const sortedEvents = upcomingEvents ? sortByStartTime(upcomingEvents) : [];
-
   return (
     <div className="space-y-2">
-      {sortedEvents && sortedEvents.length > 0 ? (
-        sortedEvents.map((event) => <UpcomingScheduleItem key={event.event_id} event={event} />)
+      {upcomingEvents && upcomingEvents.length > 0 ? (
+        upcomingEvents.map((event) => <UpcomingScheduleItem key={event.event_id} event={event} />)
       ) : (
         <div className="flex justify-center items-center h-full">
           <p className="text-sm text-gray-500">다가오는 일정이 없습니다.</p>

--- a/src/pages/TeamCalendar/components/TeamTodaySchedultList.tsx
+++ b/src/pages/TeamCalendar/components/TeamTodaySchedultList.tsx
@@ -1,15 +1,7 @@
 import { useParams } from 'react-router-dom';
 import { useTeamTodaySchedule } from '@/hooks/team';
 import { useTeamStore } from '@/store/team';
-import type { TeamSchedule } from '@/apis';
 import { TeamTodayScheduleItem } from '@/pages/TeamCalendar/components/TeamTodaySchedule';
-
-// 시작 시간 기준 오름차순 정렬
-const sortByStartTime = (schedules: TeamSchedule[]) => {
-  return [...schedules].sort(
-    (a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime(),
-  );
-};
 
 export const TeamTodayScheduleList = () => {
   const { currentTeam } = useTeamStore();
@@ -30,11 +22,9 @@ export const TeamTodayScheduleList = () => {
     return <div className="text-center text-sm text-gray-500">오늘 일정이 없습니다.</div>;
   }
 
-  const sortedSchedules = sortByStartTime(schedules);
-
   return (
     <div className="space-y-2">
-      {sortedSchedules.map((schedule) => (
+      {schedules.map((schedule) => (
         <TeamTodayScheduleItem key={schedule.event_id} schedule={schedule} />
       ))}
     </div>

--- a/src/pages/TeamCalendar/components/UpcomingTeamScheduleList.tsx
+++ b/src/pages/TeamCalendar/components/UpcomingTeamScheduleList.tsx
@@ -1,15 +1,7 @@
 import { useParams } from 'react-router-dom';
 import { useTeamUpcomingSchedule } from '@/hooks/team';
 import { useTeamStore } from '@/store/team';
-import type { TeamSchedule } from '@/apis';
 import { UpcomingTeamScheduleItem } from '@/pages/TeamCalendar/components/UpcomingTeamScheduleItem';
-
-// 시작 시간 기준 오름차순 정렬
-const sortByStartTime = (schedules: TeamSchedule[]) => {
-  return [...schedules].sort(
-    (a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime(),
-  );
-};
 
 export const UpcomingTeamScheduleList = () => {
   const { currentTeam } = useTeamStore();
@@ -30,11 +22,9 @@ export const UpcomingTeamScheduleList = () => {
     return <div className="text-center text-sm text-gray-500">예정된 일정이 없습니다.</div>;
   }
 
-  const sortedSchedules = sortByStartTime(schedules);
-
   return (
     <div className="space-y-2">
-      {sortedSchedules.map((schedule) => (
+      {schedules.map((schedule) => (
         <UpcomingTeamScheduleItem key={schedule.event_id} schedule={schedule} />
       ))}
     </div>


### PR DESCRIPTION
# 📝 PR 설명

## 변경 사항

- 다가오는 일정, 오늘의 일정, 채팅 메세지에서 프론트에서 처리했던 시간순 정렬 처리를 제거하였습니다.

## 관련 이슈

<!-- 관련된 이슈 번호를 작성해주세요 (예: #123) -->

- 관련 이슈 : #156
  Closes #156
