### PR TITLE
Refactor: 월/일/시 포멧 통일

### DIFF
--- a/src/pages/PersonalCalendar/components/TodaySchedule.tsx
+++ b/src/pages/PersonalCalendar/components/TodaySchedule.tsx
@@ -1,5 +1,5 @@
 import { useCalendarStore } from '@/store/calendar/useCalendarStore';
-import { getTimePart } from '@/utils/dateTimeUtils';
+import { formatDateWithWeekday, getTimePart } from '@/utils/dateTimeUtils';
 import { Paperclip } from 'lucide-react';
 import { useEffect } from 'react';
 
@@ -26,7 +26,8 @@ const TodaySchedule = () => {
             <div className="space-y-1">
               <p className="text-sm font-medium">{events.title}</p>
               <p className="text-xs text-gray-600">
-                {getTimePart(events.start_time)} - {getTimePart(events.end_time)}
+                {formatDateWithWeekday(events.start_time)} {getTimePart(events.start_time)}-
+                {getTimePart(events.end_time)}
               </p>
               {events.description && (
                 <p className="flex gap-1 items-center text-xs text-gray-400">

--- a/src/pages/TeamCalendar/components/RecommendTimes.tsx
+++ b/src/pages/TeamCalendar/components/RecommendTimes.tsx
@@ -3,7 +3,7 @@ import SelectBox from '@/components/atoms/SelectBox';
 import { useGetMyTeam, useTeamRecommendTimes } from '@/hooks/team/useTeam'; // import { mockTimeSlots } from '@/mockdata/teamData';
 import SelectDurationCalendar from '@/pages/TeamCalendar/components/SelectDurationCalendar';
 import '@/styles/datapicker.css';
-import { formatDateTimeShort } from '@/utils/dateTimeUtils';
+import { formatDateWithWeekday, getTimePart } from '@/utils/dateTimeUtils';
 import { Loader2 } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 import type { DateRange } from 'react-day-picker';
@@ -99,7 +99,7 @@ const RecommendTimes: React.FC<RecommendTimesProps> = ({ onViewAvailability, tea
           >
             <div className="flex gap-2 justify-between items-center">
               <div className={`font-medium text-gray-800 ${!isDesktop ? 'flex-1 min-w-0' : ''}`}>
-                {slot.week}요일
+                {formatDateWithWeekday(slot.start_time)}
               </div>
               <span
                 className={`${
@@ -112,9 +112,9 @@ const RecommendTimes: React.FC<RecommendTimesProps> = ({ onViewAvailability, tea
               </span>
             </div>
             <div
-              className={`text-gray-700 font-medium ${isDesktop ? 'mt-2 text-sm' : 'mt-1 text-xs sm:mt-2'}`}
+              className={`text-gray-600 text-medium ${isDesktop ? 'text-sm' : 'mt-1 text-xs sm:mt-2'}`}
             >
-              {formatDateTimeShort(slot.start_time)} - {formatDateTimeShort(slot.end_time)}
+              {getTimePart(slot.start_time)} - {getTimePart(slot.end_time)}
             </div>
             <div
               className={`text-gray-500 ${isDesktop ? 'mt-1 text-xs' : 'mt-1 text-xs line-clamp-2'}`}

--- a/src/pages/TeamCalendar/components/TeamAvailability/RecommendedTimeSlots.tsx
+++ b/src/pages/TeamCalendar/components/TeamAvailability/RecommendedTimeSlots.tsx
@@ -8,6 +8,7 @@ import type { CalendarEvent } from '@/types/calendar';
 import { formatDateTimeShort } from '@/utils/dateTimeUtils';
 import { useState } from 'react';
 import type { DateRange } from 'react-day-picker';
+import { formatDateWithWeekday, getTimePart } from '@/utils/dateTimeUtils';
 
 // 추천 시간대 컴포넌트
 interface RecommendedTimeSlotsProps {
@@ -80,8 +81,10 @@ const RecommendedTimeSlots: React.FC<RecommendedTimeSlotsProps> = ({
               className={`p-3 rounded-lg border border-gray-200 duration-300 cursor-pointer hover:border-mainBlue animate-all ${selectedTimeSlot?.start_time === slot.start_time ? 'border-mainBlue' : ''}`}
               onClick={() => handleSelectTimeSlot(slot)}
             >
-              <div className="flex justify-between items-center mb-2">
-                <div className="text-sm font-medium text-gray-800">{slot.week}</div>
+              <div className="flex justify-between items-center mb-1">
+                <div className="text-md font-medium text-gray-800">
+                  {formatDateWithWeekday(slot.start_time)}
+                </div>
                 <span
                   className={`px-2 py-1 text-xs font-medium rounded-full ${
                     slot.status === '최적' ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-700'
@@ -90,8 +93,8 @@ const RecommendedTimeSlots: React.FC<RecommendedTimeSlotsProps> = ({
                   {slot.status}
                 </span>
               </div>
-              <div className="text-sm font-medium text-gray-700">
-                {formatDateTimeShort(slot.start_time)} - {formatDateTimeShort(slot.end_time)}
+              <div className="text-sm font-medium text-gray-600">
+                {getTimePart(slot.start_time)} - {getTimePart(slot.end_time)}
               </div>
               <div className="mt-1 text-xs text-gray-500">
                 {slot.available} / {memberCount} 명

--- a/src/pages/TeamCalendar/components/TeamAvailability/RecommendedTimeSlots.tsx
+++ b/src/pages/TeamCalendar/components/TeamAvailability/RecommendedTimeSlots.tsx
@@ -5,7 +5,6 @@ import type { FormData } from '@/hooks/calendar/useFormData';
 import { useTeamRecommendTimes } from '@/hooks/team/useTeam';
 import DateModal from '@/pages/Calendar/components/DateModal';
 import type { CalendarEvent } from '@/types/calendar';
-import { formatDateTimeShort } from '@/utils/dateTimeUtils';
 import { useState } from 'react';
 import type { DateRange } from 'react-day-picker';
 import { formatDateWithWeekday, getTimePart } from '@/utils/dateTimeUtils';


### PR DESCRIPTION
# 📝 PR 설명

## 변경 사항

- 모든 컴포넌트에 동일한 월/일/시 포멧을 적용합니다.

## 상세 설명

<!-- 변경 사항에 대한 자세한 설명을 작성해주세요 -->
- 팀원 가용성 시간 선택 페이지에서 월 / 일 / 시 포멧을 "다가오는 일정"의 시간표시 포멧과 동일하게 구현합니다.

## 관련 이슈

<!-- 관련된 이슈 번호를 작성해주세요 (예: #123) -->

- 관련 이슈 : #165 
  Closes #165

## 스크린샷 (UI 변경이 있는 경우)

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

<img width="367" height="587" alt="스크린샷 2025-11-06 오전 10 38 41" src="https://github.com/user-attachments/assets/018896b1-2a83-4fc5-94f3-d132b1a35df5" />

<img width="247" height="461" alt="스크린샷 2025-11-06 오전 10 38 31" src="https://github.com/user-attachments/assets/ba69c2b2-00d2-45b6-94ec-f6ab39939749" />

<img width="367" height="587" alt="스크린샷 2025-11-06 오전 10 38 41" src="https://github.com/user-attachments/assets/294b84c8-46b1-487e-822d-d75b136e9d12" />

