### PR TITLE
Feat: 가입 코드 복사 기능 추가 및 클릭 시 팀 캘린더 이동 차단

### DIFF
--- a/src/hooks/useDisableBodyScroll.ts
+++ b/src/hooks/useDisableBodyScroll.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+
+/**
+ * 모달이 열릴 때 배경 스크롤을 차단하는 훅
+ * @param isOpen 모달의 열림/닫힘 상태
+ */
+export const useDisableBodyScroll = (isOpen: boolean) => {
+  useEffect(() => {
+    if (isOpen) {
+      // 현재 스크롤 위치 저장
+      const scrollY = window.scrollY;
+      
+      // 배경 스크롤 차단
+      document.body.style.position = 'fixed';
+      document.body.style.top = `-${scrollY}px`;
+      document.body.style.width = '100%';
+      document.body.style.overflow = 'hidden';
+    } else {
+      // 스크롤 위치 복원
+      const scrollY = document.body.style.top;
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.body.style.width = '';
+      document.body.style.overflow = '';
+      
+      // 저장된 스크롤 위치로 복원
+      if (scrollY) {
+        window.scrollTo(0, parseInt(scrollY || '0', 10) * -1);
+      }
+    }
+
+    // cleanup: 컴포넌트 언마운트 시 스크롤 복원
+    return () => {
+      const scrollY = document.body.style.top;
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.body.style.width = '';
+      document.body.style.overflow = '';
+      
+      if (scrollY) {
+        window.scrollTo(0, parseInt(scrollY || '0', 10) * -1);
+      }
+    };
+  }, [isOpen]);
+};

--- a/src/pages/PersonalCalendar/components/TeamListCard.tsx
+++ b/src/pages/PersonalCalendar/components/TeamListCard.tsx
@@ -1,6 +1,6 @@
 import type { TeamData } from '@/apis/types/team';
 import Button from '@/components/atoms/Button';
-import { Calendar, LogOut, Settings, Trash, Users } from 'lucide-react';
+import { Calendar, LogOut, Settings, Trash, Users, Copy } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
@@ -55,6 +55,18 @@ const TeamListCard = ({ team, leaveTeam, deleteTeam }: TeamListCardProps) => {
       return;
     }
     navigate(`/team-calendar/${team.id}`);
+  };
+
+  // 가입 코드 복사
+  const handleCopyInviteCode = async (e: React.MouseEvent) => {
+    e.stopPropagation(); // 카드 클릭 방지
+    
+    try {
+      await navigator.clipboard.writeText(team.invite_code);
+      toast.success('가입 코드가 복사되었습니다.');
+    } catch (err) {
+      toast.error('복사에 실패했습니다.');
+    }
   };
 
   return (
@@ -144,9 +156,14 @@ const TeamListCard = ({ team, leaveTeam, deleteTeam }: TeamListCardProps) => {
           </div>
 
           <div className="flex items-center space-x-2">
-            <span className="px-2 py-1 font-mono text-xs font-medium text-gray-600 bg-gray-100 rounded-full border border-gray-200">
-              {team.invite_code}
-            </span>
+            <button
+              onClick={handleCopyInviteCode}
+              className="flex items-center gap-1 px-2 py-1 font-mono text-xs font-medium text-gray-600 bg-gray-100 rounded-full border border-gray-200 hover:bg-gray-200 hover:text-gray-800 transition-colors cursor-pointer"
+              title="가입 코드 복사"
+            >
+              <span>{team.invite_code}</span>
+              <Copy className="w-3 h-3" />
+            </button>
             <Button
               noWrapper
               variant="ghost"


### PR DESCRIPTION
# 📝 PR 설명

## 변경 사항

- 가입 코드 복사 기능을 추가하였습니다.
- 가입 코드 복사 시 카드가 클릭되어 팀 캘린더로 넘어가는 것을 차단했습니다.

## 관련 이슈

<!-- 관련된 이슈 번호를 작성해주세요 (예: #123) -->

- 관련 이슈 : #181 
  Closes #181
