### PR TITLE
Refactor: 기존에 저장된 멤버가 선택되도록 구현

### DIFF
--- a/src/apis/types/calendar.ts
+++ b/src/apis/types/calendar.ts
@@ -23,6 +23,7 @@ export type getTeamCalendarEventsResponse = {
   start_time: string;
   end_time?: string;
   is_recurring: boolean;
+  event_participants?: number[];
 }[];
 
 //팀 일정 추가

--- a/src/hooks/calendar/useFormData.ts
+++ b/src/hooks/calendar/useFormData.ts
@@ -71,8 +71,7 @@ const useFormData = ({
           repeatEndDate: '',
           repeatCount: 1,
           repeatWeekDays: [],
-          // startTime: new Date(selectedEvent.start_time).toTimeString().slice(0, 5),
-          // endTime: new Date(selectedEvent.end_time).toTimeString().slice(0, 5),
+          event_participants: selectedEvent.event_participants,
         });
       } else if (modalType === 'add' && (initialStartTime || selectedDate)) {
         setFormData({

--- a/src/pages/Calendar/components/MetaFields.tsx
+++ b/src/pages/Calendar/components/MetaFields.tsx
@@ -2,7 +2,7 @@ import { FormInput } from '@/components/atoms/FormInput';
 import MemberSelectDropdown from '@/pages/Calendar/components/MemberSelectDropdown';
 import { getDatePart } from '@/utils/dateTimeUtils';
 import type { FormData } from '@/hooks/calendar/useFormData';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import type { DateRange } from 'react-day-picker';
 
 interface MetaFieldsProps {
@@ -15,6 +15,12 @@ interface MetaFieldsProps {
 const MetaFields: React.FC<MetaFieldsProps> = ({ formData, range, updateFormData, teamId }) => {
   const [error, setError] = useState<string | null>(null);
   const [selectedMemberIds, setSelectedMemberIds] = useState<number[]>([]);
+
+  useEffect(() => {
+    if (formData.event_participants !== undefined) {
+      setSelectedMemberIds(formData.event_participants);
+    }
+  }, [formData.event_participants]);
 
   const handleAllDayChange = (value: string) => {
     const isAllDay = value === 'true';

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -17,6 +17,7 @@ export type CalendarEvent = {
   start_time: string; // ISO string e.g. 2025-09-18T10:00:00
   end_time: string; // ISO string e.g. 2025-09-18T11:00:00
   is_recurring?: boolean;
+  event_participants?: number[];
 };
 
 export type getCalendarEventsResponse = {


### PR DESCRIPTION
# 📝 PR 설명

## 변경 사항

- 해당 일정의 수정 모달에서 기존에 저장된 멤버가 선택되어있도록 코드를 수정했습니다.

## 관련 이슈

<!-- 관련된 이슈 번호를 작성해주세요 (예: #123) -->

- 관련 이슈 : #162 
  Closes #162 
